### PR TITLE
Properly convert script-paths to types

### DIFF
--- a/godot/Godot.hx
+++ b/godot/Godot.hx
@@ -111,7 +111,7 @@ class Godot {
 
 		for (line in File.getContent(filename).split("\n")) {
 			if (line.startsWith(ext)) {
-				scripts.push(line.substring(ext.length, line.indexOf('.cs" type="Script" id=')));
+				scripts.push(line.substring(ext.length, line.indexOf('.cs" type="Script" id=')).replace("/", "."));
 			}
 		}
 


### PR DESCRIPTION
When using subfolders, replace slashes with dots to properly convert the path to a type.