### PR TITLE
Regenerate for 3.4.5

### DIFF
--- a/godot/ARVRAnchor.hx
+++ b/godot/ARVRAnchor.hx
@@ -18,8 +18,6 @@ Keep in mind that, as long as plane detection is enabled, the size, placing and 
 extern class ARVRAnchor extends godot.Spatial {
 	/**
 		`mesh_updated` signal.
-		
-		Emitted when the mesh associated with the anchor changes or when one becomes available. This is especially important for topology that is constantly being `mesh_updated`.
 	**/
 	public var onMeshUpdated(get, never):Signal<(mesh:Mesh)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMeshUpdated():Signal<(mesh:Mesh)->Void> {

--- a/godot/ARVRController.hx
+++ b/godot/ARVRController.hx
@@ -18,8 +18,6 @@ The position of the controller node is automatically updated by the `godot.ARVRS
 extern class ARVRController extends godot.Spatial {
 	/**
 		`button_pressed` signal.
-		
-		Emitted when a button on this controller is pressed.
 	**/
 	public var onButtonPressed(get, never):Signal<(button:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onButtonPressed():Signal<(button:Int)->Void> {
@@ -28,8 +26,6 @@ extern class ARVRController extends godot.Spatial {
 
 	/**
 		`button_release` signal.
-		
-		Emitted when a button on this controller is released.
 	**/
 	public var onButtonRelease(get, never):Signal<(button:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onButtonRelease():Signal<(button:Int)->Void> {
@@ -38,8 +34,6 @@ extern class ARVRController extends godot.Spatial {
 
 	/**
 		`mesh_updated` signal.
-		
-		Emitted when the mesh associated with the controller changes or when one becomes available. Generally speaking this will be a static mesh after becoming available.
 	**/
 	public var onMeshUpdated(get, never):Signal<(mesh:Mesh)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMeshUpdated():Signal<(mesh:Mesh)->Void> {

--- a/godot/ARVRServer.hx
+++ b/godot/ARVRServer.hx
@@ -14,8 +14,6 @@ The AR/VR server is the heart of our Advanced and Virtual Reality solution and h
 extern class ARVRServer {
 	/**
 		`interface_added` signal.
-		
-		Emitted when a new interface has been added.
 	**/
 	public static var onInterfaceAdded(get, never):Signal<(interfaceName:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onInterfaceAdded():Signal<(interfaceName:std.String)->Void> {
@@ -24,8 +22,6 @@ extern class ARVRServer {
 
 	/**
 		`interface_removed` signal.
-		
-		Emitted when an interface is removed.
 	**/
 	public static var onInterfaceRemoved(get, never):Signal<(interfaceName:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onInterfaceRemoved():Signal<(interfaceName:std.String)->Void> {
@@ -34,8 +30,6 @@ extern class ARVRServer {
 
 	/**
 		`tracker_added` signal.
-		
-		Emitted when a new tracker has been added. If you don't use a fixed number of controllers or if you're using `ARVRAnchor`s for an AR solution, it is important to react to this signal to add the appropriate `ARVRController` or `ARVRAnchor` nodes related to this new tracker.
 	**/
 	public static var onTrackerAdded(get, never):Signal<(trackerName:std.String, type:Int, id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onTrackerAdded():Signal<(trackerName:std.String, type:Int, id:Int)->Void> {
@@ -44,8 +38,6 @@ extern class ARVRServer {
 
 	/**
 		`tracker_removed` signal.
-		
-		Emitted when a tracker is removed. You should remove any `ARVRController` or `ARVRAnchor` points if applicable. This is not mandatory, the nodes simply become inactive and will be made active again when a new tracker becomes available (i.e. a new controller is switched on that takes the place of the previous one).
 	**/
 	public static var onTrackerRemoved(get, never):Signal<(trackerName:std.String, type:Int, id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onTrackerRemoved():Signal<(trackerName:std.String, type:Int, id:Int)->Void> {

--- a/godot/AcceptDialog.hx
+++ b/godot/AcceptDialog.hx
@@ -14,8 +14,6 @@ This dialog is useful for small notifications to the user about an event. It can
 extern class AcceptDialog extends godot.WindowDialog {
 	/**
 		`confirmed` signal.
-		
-		Emitted when the dialog is accepted, i.e. the OK button is pressed.
 	**/
 	public var onConfirmed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConfirmed():Signal<Void->Void> {
@@ -24,8 +22,6 @@ extern class AcceptDialog extends godot.WindowDialog {
 
 	/**
 		`custom_action` signal.
-		
-		Emitted when a custom button is pressed. See `addButton`.
 	**/
 	public var onCustomAction(get, never):Signal<(action:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCustomAction():Signal<(action:std.String)->Void> {

--- a/godot/AnimatedSprite.hx
+++ b/godot/AnimatedSprite.hx
@@ -16,8 +16,6 @@ Note: You can associate a set of normal maps by creating additional `godot.Sprit
 extern class AnimatedSprite extends godot.Node2D {
 	/**
 		`animation_finished` signal.
-		
-		Emitted when the animation is finished (when it plays the last frame). If the animation is looping, this signal is emitted every time the last frame is drawn.
 	**/
 	public var onAnimationFinished(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAnimationFinished():Signal<Void->Void> {
@@ -26,8 +24,6 @@ extern class AnimatedSprite extends godot.Node2D {
 
 	/**
 		`frame_changed` signal.
-		
-		Emitted when `frame` changed.
 	**/
 	public var onFrameChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFrameChanged():Signal<Void->Void> {

--- a/godot/AnimatedSprite3D.hx
+++ b/godot/AnimatedSprite3D.hx
@@ -14,8 +14,6 @@ Animations are created using a `godot.SpriteFrames` resource, which can be confi
 extern class AnimatedSprite3D extends godot.SpriteBase3D {
 	/**
 		`animation_finished` signal.
-		
-		Emitted when the animation is finished (when it plays the last frame). If the animation is looping, this signal is emitted every time the last frame is drawn.
 	**/
 	public var onAnimationFinished(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAnimationFinished():Signal<Void->Void> {
@@ -24,8 +22,6 @@ extern class AnimatedSprite3D extends godot.SpriteBase3D {
 
 	/**
 		`frame_changed` signal.
-		
-		Emitted when `frame` changed.
 	**/
 	public var onFrameChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFrameChanged():Signal<Void->Void> {

--- a/godot/Animation.hx
+++ b/godot/Animation.hx
@@ -28,8 +28,6 @@ Animations are just data containers, and must be added to nodes such as an `godo
 extern class Animation extends godot.Resource {
 	/**
 		`tracks_changed` signal.
-		
-		Emitted when there's a change in the list of tracks, e.g. tracks are added, moved or have changed paths.
 	**/
 	public var onTracksChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTracksChanged():Signal<Void->Void> {

--- a/godot/AnimationNode.hx
+++ b/godot/AnimationNode.hx
@@ -16,8 +16,6 @@ Inherit this when creating nodes mainly for use in `godot.AnimationNodeBlendTree
 extern class AnimationNode extends godot.Resource {
 	/**
 		`removed_from_graph` signal.
-		
-		Called when the node was removed from the graph.
 	**/
 	public var onRemovedFromGraph(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRemovedFromGraph():Signal<Void->Void> {
@@ -26,8 +24,6 @@ extern class AnimationNode extends godot.Resource {
 
 	/**
 		`tree_changed` signal.
-		
-		Emitted by nodes that inherit from this class and that have an internal tree when one of their nodes changes. The nodes that emit this signal are `AnimationNodeBlendSpace1D`, `AnimationNodeBlendSpace2D`, `AnimationNodeStateMachine`, and `AnimationNodeBlendTree`.
 	**/
 	public var onTreeChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTreeChanged():Signal<Void->Void> {
@@ -123,7 +119,7 @@ extern class AnimationNode extends godot.Resource {
 	public function setFilterPath(path:godot.NodePath, enable:Bool):Void;
 
 	/**		
-		Returns `true` whether a given path is filtered.
+		Returns whether the given path is filtered.
 	**/
 	@:native("IsPathFiltered")
 	public function isPathFiltered(path:godot.NodePath):Bool;
@@ -193,7 +189,7 @@ extern class AnimationNode extends godot.Resource {
 	#end
 
 	/**		
-		Sets a custom parameter. These are used as local storage, because resources can be reused across the tree or scenes.
+		Sets a custom parameter. These are used as local memory, because resources can be reused across the tree or scenes.
 	**/
 	@:native("SetParameter")
 	public function setParameter(name:std.String, value:Dynamic):Void;

--- a/godot/AnimationNodeBlendSpace2D.hx
+++ b/godot/AnimationNodeBlendSpace2D.hx
@@ -18,8 +18,6 @@ You can add vertices to the blend space with `godot.AnimationNodeBlendSpace2D.ad
 extern class AnimationNodeBlendSpace2D extends godot.AnimationRootNode {
 	/**
 		`triangles_updated` signal.
-		
-		Emitted every time the blend space's triangles are created, removed, or when one of their vertices changes position.
 	**/
 	public var onTrianglesUpdated(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTrianglesUpdated():Signal<Void->Void> {

--- a/godot/AnimationNodeOneShot.hx
+++ b/godot/AnimationNodeOneShot.hx
@@ -39,6 +39,9 @@ extern class AnimationNodeOneShot extends godot.AnimationNode {
 	@:native("FadeinTime")
 	public var fadeinTime:Single;
 
+	@:native("MixMode")
+	public var mixMode:godot.AnimationNodeOneShot_MixModeEnum;
+
 	@:native("new")
 	public function new():Void;
 
@@ -73,10 +76,10 @@ extern class AnimationNodeOneShot extends godot.AnimationNode {
 	public function getAutorestartRandomDelay():Single;
 
 	@:native("SetMixMode")
-	public function setMixMode(mode:godot.AnimationNodeOneShot_MixMode):Void;
+	public function setMixMode(mode:godot.AnimationNodeOneShot_MixModeEnum):Void;
 
 	@:native("GetMixMode")
-	public function getMixMode():godot.AnimationNodeOneShot_MixMode;
+	public function getMixMode():godot.AnimationNodeOneShot_MixModeEnum;
 
 	@:native("SetUseSync")
 	public function setUseSync(enable:Bool):Void;

--- a/godot/AnimationNodeOneShot_MixModeEnum.hx
+++ b/godot/AnimationNodeOneShot_MixModeEnum.hx
@@ -2,9 +2,9 @@
 // MIT licensed, see LICENSE.md
 package godot;
 
-@:native("Godot.AnimationNodeOneShot.MixMode")
+@:native("Godot.AnimationNodeOneShot.MixModeEnum")
 @:csNative
-extern enum AnimationNodeOneShot_MixMode {
+extern enum AnimationNodeOneShot_MixModeEnum {
 	Blend;
 
 	Add;

--- a/godot/AnimationNodeStateMachineTransition.hx
+++ b/godot/AnimationNodeStateMachineTransition.hx
@@ -11,8 +11,6 @@ import cs.system.*;
 extern class AnimationNodeStateMachineTransition extends godot.Resource {
 	/**
 		`advance_condition_changed` signal.
-		
-		Emitted when `advanceCondition` is changed.
 	**/
 	public var onAdvanceConditionChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAdvanceConditionChanged():Signal<Void->Void> {

--- a/godot/AnimationPlayer.hx
+++ b/godot/AnimationPlayer.hx
@@ -18,9 +18,6 @@ Updating the target properties of animations occurs at process time.
 extern class AnimationPlayer extends godot.Node {
 	/**
 		`animation_changed` signal.
-		
-		Emitted when a queued animation plays after the previous animation was finished. See `queue`.
-		`b`Note:`/b` The signal is not emitted when the animation is changed via `play` or from `AnimationTree`.
 	**/
 	public var onAnimationChanged(get, never):Signal<(oldName:std.String, newName:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAnimationChanged():Signal<(oldName:std.String, newName:std.String)->Void> {
@@ -29,8 +26,6 @@ extern class AnimationPlayer extends godot.Node {
 
 	/**
 		`animation_finished` signal.
-		
-		Notifies when an animation finished playing.
 	**/
 	public var onAnimationFinished(get, never):Signal<(animName:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAnimationFinished():Signal<(animName:std.String)->Void> {
@@ -39,8 +34,6 @@ extern class AnimationPlayer extends godot.Node {
 
 	/**
 		`animation_started` signal.
-		
-		Notifies when an animation starts playing.
 	**/
 	public var onAnimationStarted(get, never):Signal<(animName:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAnimationStarted():Signal<(animName:std.String)->Void> {
@@ -49,8 +42,6 @@ extern class AnimationPlayer extends godot.Node {
 
 	/**
 		`caches_cleared` signal.
-		
-		Notifies when the caches have been cleared, either automatically, or manually via `clearCaches`.
 	**/
 	public var onCachesCleared(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCachesCleared():Signal<Void->Void> {

--- a/godot/Area.hx
+++ b/godot/Area.hx
@@ -14,9 +14,6 @@ import cs.system.*;
 extern class Area extends godot.CollisionObject {
 	/**
 		`area_entered` signal.
-		
-		Emitted when another Area enters this Area. Requires `monitoring` to be set to `true`.
-		`area` the other Area.
 	**/
 	public var onAreaEntered(get, never):Signal<(area:Area)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAreaEntered():Signal<(area:Area)->Void> {
@@ -25,9 +22,6 @@ extern class Area extends godot.CollisionObject {
 
 	/**
 		`area_exited` signal.
-		
-		Emitted when another Area exits this Area. Requires `monitoring` to be set to `true`.
-		`area` the other Area.
 	**/
 	public var onAreaExited(get, never):Signal<(area:Area)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAreaExited():Signal<(area:Area)->Void> {
@@ -36,12 +30,6 @@ extern class Area extends godot.CollisionObject {
 
 	/**
 		`area_shape_entered` signal.
-		
-		Emitted when one of another Area's `Shape`s enters one of this Area's `Shape`s. Requires `monitoring` to be set to `true`.
-		`area_rid` the `RID` of the other Area's `CollisionObject` used by the `PhysicsServer`.
-		`area` the other Area.
-		`area_shape_index` the index of the `Shape` of the other Area used by the `PhysicsServer`. Get the `CollisionShape` node with `area.shape_owner_get_owner(area_shape_index)`.
-		`local_shape_index` the index of the `Shape` of this Area used by the `PhysicsServer`. Get the `CollisionShape` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onAreaShapeEntered(get, never):Signal<(areaRid:RID, area:Area, areaShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAreaShapeEntered():Signal<(areaRid:RID, area:Area, areaShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -50,12 +38,6 @@ extern class Area extends godot.CollisionObject {
 
 	/**
 		`area_shape_exited` signal.
-		
-		Emitted when one of another Area's `Shape`s enters one of this Area's `Shape`s. Requires `monitoring` to be set to `true`.
-		`area_rid` the `RID` of the other Area's `CollisionObject` used by the `PhysicsServer`.
-		`area` the other Area.
-		`area_shape_index` the index of the `Shape` of the other Area used by the `PhysicsServer`. Get the `CollisionShape` node with `area.shape_owner_get_owner(area_shape_index)`.
-		`local_shape_index` the index of the `Shape` of this Area used by the `PhysicsServer`. Get the `CollisionShape` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onAreaShapeExited(get, never):Signal<(areaRid:RID, area:Area, areaShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAreaShapeExited():Signal<(areaRid:RID, area:Area, areaShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -64,9 +46,6 @@ extern class Area extends godot.CollisionObject {
 
 	/**
 		`body_entered` signal.
-		
-		Emitted when a `PhysicsBody` or `GridMap` enters this Area. Requires `monitoring` to be set to `true`. `GridMap`s are detected if the `MeshLibrary` has Collision `Shape`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody` or `GridMap`.
 	**/
 	public var onBodyEntered(get, never):Signal<(body:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyEntered():Signal<(body:Node)->Void> {
@@ -75,9 +54,6 @@ extern class Area extends godot.CollisionObject {
 
 	/**
 		`body_exited` signal.
-		
-		Emitted when a `PhysicsBody` or `GridMap` exits this Area. Requires `monitoring` to be set to `true`. `GridMap`s are detected if the `MeshLibrary` has Collision `Shape`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody` or `GridMap`.
 	**/
 	public var onBodyExited(get, never):Signal<(body:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyExited():Signal<(body:Node)->Void> {
@@ -86,12 +62,6 @@ extern class Area extends godot.CollisionObject {
 
 	/**
 		`body_shape_entered` signal.
-		
-		Emitted when one of a `PhysicsBody` or `GridMap`'s `Shape`s enters one of this Area's `Shape`s. Requires `monitoring` to be set to `true`. `GridMap`s are detected if the `MeshLibrary` has Collision `Shape`s.
-		`body_rid` the `RID` of the `PhysicsBody` or `MeshLibrary`'s `CollisionObject` used by the `PhysicsServer`.
-		`body` the `Node`, if it exists in the tree, of the `PhysicsBody` or `GridMap`.
-		`body_shape_index` the index of the `Shape` of the `PhysicsBody` or `GridMap` used by the `PhysicsServer`. Get the `CollisionShape` node with `body.shape_owner_get_owner(body_shape_index)`.
-		`local_shape_index` the index of the `Shape` of this Area used by the `PhysicsServer`. Get the `CollisionShape` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onBodyShapeEntered(get, never):Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyShapeEntered():Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -100,12 +70,6 @@ extern class Area extends godot.CollisionObject {
 
 	/**
 		`body_shape_exited` signal.
-		
-		Emitted when one of a `PhysicsBody` or `GridMap`'s `Shape`s enters one of this Area's `Shape`s. Requires `monitoring` to be set to `true`. `GridMap`s are detected if the `MeshLibrary` has Collision `Shape`s.
-		`body_rid` the `RID` of the `PhysicsBody` or `MeshLibrary`'s `CollisionObject` used by the `PhysicsServer`.
-		`body` the `Node`, if it exists in the tree, of the `PhysicsBody` or `GridMap`.
-		`body_shape_index` the index of the `Shape` of the `PhysicsBody` or `GridMap` used by the `PhysicsServer`. Get the `CollisionShape` node with `body.shape_owner_get_owner(body_shape_index)`.
-		`local_shape_index` the index of the `Shape` of this Area used by the `PhysicsServer`. Get the `CollisionShape` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onBodyShapeExited(get, never):Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyShapeExited():Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void> {

--- a/godot/Area2D.hx
+++ b/godot/Area2D.hx
@@ -14,9 +14,6 @@ import cs.system.*;
 extern class Area2D extends godot.CollisionObject2D {
 	/**
 		`area_entered` signal.
-		
-		Emitted when another Area2D enters this Area2D. Requires `monitoring` to be set to `true`.
-		`area` the other Area2D.
 	**/
 	public var onAreaEntered(get, never):Signal<(area:Area2D)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAreaEntered():Signal<(area:Area2D)->Void> {
@@ -25,9 +22,6 @@ extern class Area2D extends godot.CollisionObject2D {
 
 	/**
 		`area_exited` signal.
-		
-		Emitted when another Area2D exits this Area2D. Requires `monitoring` to be set to `true`.
-		`area` the other Area2D.
 	**/
 	public var onAreaExited(get, never):Signal<(area:Area2D)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAreaExited():Signal<(area:Area2D)->Void> {
@@ -36,12 +30,6 @@ extern class Area2D extends godot.CollisionObject2D {
 
 	/**
 		`area_shape_entered` signal.
-		
-		Emitted when one of another Area2D's `Shape2D`s enters one of this Area2D's `Shape2D`s. Requires `monitoring` to be set to `true`.
-		`area_rid` the `RID` of the other Area2D's `CollisionObject2D` used by the `Physics2DServer`.
-		`area` the other Area2D.
-		`area_shape_index` the index of the `Shape2D` of the other Area2D used by the `Physics2DServer`. Get the `CollisionShape2D` node with `area.shape_owner_get_owner(area_shape_index)`.
-		`local_shape_index` the index of the `Shape2D` of this Area2D used by the `Physics2DServer`. Get the `CollisionShape2D` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onAreaShapeEntered(get, never):Signal<(areaRid:RID, area:Area2D, areaShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAreaShapeEntered():Signal<(areaRid:RID, area:Area2D, areaShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -50,12 +38,6 @@ extern class Area2D extends godot.CollisionObject2D {
 
 	/**
 		`area_shape_exited` signal.
-		
-		Emitted when one of another Area2D's `Shape2D`s exits one of this Area2D's `Shape2D`s. Requires `monitoring` to be set to `true`.
-		`area_rid` the `RID` of the other Area2D's `CollisionObject2D` used by the `Physics2DServer`.
-		`area` the other Area2D.
-		`area_shape_index` the index of the `Shape2D` of the other Area2D used by the `Physics2DServer`. Get the `CollisionShape2D` node with `area.shape_owner_get_owner(area_shape_index)`.
-		`local_shape_index` the index of the `Shape2D` of this Area2D used by the `Physics2DServer`. Get the `CollisionShape2D` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onAreaShapeExited(get, never):Signal<(areaRid:RID, area:Area2D, areaShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAreaShapeExited():Signal<(areaRid:RID, area:Area2D, areaShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -64,9 +46,6 @@ extern class Area2D extends godot.CollisionObject2D {
 
 	/**
 		`body_entered` signal.
-		
-		Emitted when a `PhysicsBody2D` or `TileMap` enters this Area2D. Requires `monitoring` to be set to `true`. `TileMap`s are detected if the `TileSet` has Collision `Shape2D`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody2D` or `TileMap`.
 	**/
 	public var onBodyEntered(get, never):Signal<(body:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyEntered():Signal<(body:Node)->Void> {
@@ -75,9 +54,6 @@ extern class Area2D extends godot.CollisionObject2D {
 
 	/**
 		`body_exited` signal.
-		
-		Emitted when a `PhysicsBody2D` or `TileMap` exits this Area2D. Requires `monitoring` to be set to `true`. `TileMap`s are detected if the `TileSet` has Collision `Shape2D`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody2D` or `TileMap`.
 	**/
 	public var onBodyExited(get, never):Signal<(body:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyExited():Signal<(body:Node)->Void> {
@@ -86,12 +62,6 @@ extern class Area2D extends godot.CollisionObject2D {
 
 	/**
 		`body_shape_entered` signal.
-		
-		Emitted when one of a `PhysicsBody2D` or `TileMap`'s `Shape2D`s enters one of this Area2D's `Shape2D`s. Requires `monitoring` to be set to `true`. `TileMap`s are detected if the `TileSet` has Collision `Shape2D`s.
-		`body_rid` the `RID` of the `PhysicsBody2D` or `TileSet`'s `CollisionObject2D` used by the `Physics2DServer`.
-		`body` the `Node`, if it exists in the tree, of the `PhysicsBody2D` or `TileMap`.
-		`body_shape_index` the index of the `Shape2D` of the `PhysicsBody2D` or `TileMap` used by the `Physics2DServer`. Get the `CollisionShape2D` node with `body.shape_owner_get_owner(body_shape_index)`.
-		`local_shape_index` the index of the `Shape2D` of this Area2D used by the `Physics2DServer`. Get the `CollisionShape2D` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onBodyShapeEntered(get, never):Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyShapeEntered():Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -100,12 +70,6 @@ extern class Area2D extends godot.CollisionObject2D {
 
 	/**
 		`body_shape_exited` signal.
-		
-		Emitted when one of a `PhysicsBody2D` or `TileMap`'s `Shape2D`s exits one of this Area2D's `Shape2D`s. Requires `monitoring` to be set to `true`. `TileMap`s are detected if the `TileSet` has Collision `Shape2D`s.
-		`body_rid` the `RID` of the `PhysicsBody2D` or `TileSet`'s `CollisionObject2D` used by the `Physics2DServer`.
-		`body` the `Node`, if it exists in the tree, of the `PhysicsBody2D` or `TileMap`.
-		`body_shape_index` the index of the `Shape2D` of the `PhysicsBody2D` or `TileMap` used by the `Physics2DServer`. Get the `CollisionShape2D` node with `body.shape_owner_get_owner(body_shape_index)`.
-		`local_shape_index` the index of the `Shape2D` of this Area2D used by the `Physics2DServer`. Get the `CollisionShape2D` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onBodyShapeExited(get, never):Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyShapeExited():Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void> {

--- a/godot/AudioEffectCapture.hx
+++ b/godot/AudioEffectCapture.hx
@@ -7,7 +7,7 @@ import cs.system.*;
 /**
 AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer.
 
-Application code should consume these audio frames from this ring buffer using `godot.AudioEffectCapture.getBuffer` and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network.
+Application code should consume these audio frames from this ring buffer using `godot.AudioEffectCapture.getBuffer` and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating point PCM.
 **/
 @:libType
 @:csNative

--- a/godot/AudioEffectRecord.hx
+++ b/godot/AudioEffectRecord.hx
@@ -5,7 +5,11 @@ package godot;
 import cs.system.*;
 
 /**
-Allows the user to record sound from a microphone. It sets and gets the format in which the audio file will be recorded (8-bit, 16-bit, or compressed). It checks whether or not the recording is active, and if it is, records the sound. It then returns the recorded sample.
+Allows the user to record the sound from an audio bus. This can include all audio output by Godot when used on the "Master" audio bus.
+
+Can be used (with an `godot.AudioStreamMicrophone`) to record from a microphone.
+
+It sets and gets the format in which the audio file will be recorded (8-bit, 16-bit, or compressed). It checks whether or not the recording is active, and if it is, records the sound. It then returns the recorded sample.
 **/
 @:libType
 @:csNative

--- a/godot/AudioServer.hx
+++ b/godot/AudioServer.hx
@@ -14,8 +14,6 @@ import cs.system.*;
 extern class AudioServer {
 	/**
 		`bus_layout_changed` signal.
-		
-		Emitted when the `AudioBusLayout` changes.
 	**/
 	public static var onBusLayoutChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onBusLayoutChanged():Signal<Void->Void> {
@@ -32,7 +30,7 @@ extern class AudioServer {
 	public static var GLOBAL_RATE_SCALE:Single;
 
 	/**		
-		Name of the current device for audio output (see `godot.AudioServer.getDeviceList`).
+		Name of the current device for audio output (see `godot.AudioServer.getDeviceList`). On systems with multiple audio outputs (such as analog, USB and HDMI audio), this can be used to select the audio output device. The value `"Default"` will play audio on the system-wide default audio output. If an invalid device name is set, the value will be reverted back to `"Default"`.
 	**/
 	@:native("Device")
 	public static var DEVICE:std.String;
@@ -322,13 +320,13 @@ extern class AudioServer {
 	public static function captureGetDeviceList():godot.collections.Array;
 
 	/**		
-		Name of the current device for audio input (see `godot.AudioServer.captureGetDeviceList`).
+		Name of the current device for audio input (see `godot.AudioServer.captureGetDeviceList`). The value `"Default"` means that the system-wide default audio input is currently used.
 	**/
 	@:native("CaptureGetDevice")
 	public static function captureGetDevice():std.String;
 
 	/**		
-		Sets which audio input device is used for audio capture.
+		Sets which audio input device is used for audio capture. On systems with multiple audio inputs (such as analog and USB), this can be used to select the audio input device. Setting the value `"Default"` will record audio from the system-wide default audio input. If an invalid device name is set, the value will be reverted back to `"Default"`.
 	**/
 	@:native("CaptureSetDevice")
 	public static function captureSetDevice(name:std.String):Void;

--- a/godot/AudioStreamPlayer.hx
+++ b/godot/AudioStreamPlayer.hx
@@ -16,8 +16,6 @@ To play audio positionally, use `godot.AudioStreamPlayer2D` or `godot.AudioStrea
 extern class AudioStreamPlayer extends godot.Node {
 	/**
 		`finished` signal.
-		
-		Emitted when the audio stops playing.
 	**/
 	public var onFinished(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFinished():Signal<Void->Void> {

--- a/godot/AudioStreamPlayer2D.hx
+++ b/godot/AudioStreamPlayer2D.hx
@@ -18,8 +18,6 @@ Note: Hiding an `godot.AudioStreamPlayer2D` node does not disable its audio outp
 extern class AudioStreamPlayer2D extends godot.Node2D {
 	/**
 		`finished` signal.
-		
-		Emitted when the audio stops playing.
 	**/
 	public var onFinished(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFinished():Signal<Void->Void> {
@@ -27,7 +25,7 @@ extern class AudioStreamPlayer2D extends godot.Node2D {
 	}
 
 	/**		
-		Areas in which this sound plays.
+		Determines which `godot.Area2D` layers affect the sound for reverb and audio bus effects. Areas can be used to redirect `godot.AudioStream`s so that they play in a certain audio bus. An example of how you might use this is making a "water" area so that sounds played in the water are redirected through an audio bus to make them sound like they are being played underwater.
 	**/
 	@:native("AreaMask")
 	public var areaMask:UInt;

--- a/godot/AudioStreamPlayer3D.hx
+++ b/godot/AudioStreamPlayer3D.hx
@@ -20,8 +20,6 @@ Note: Hiding an `godot.AudioStreamPlayer3D` node does not disable its audio outp
 extern class AudioStreamPlayer3D extends godot.Spatial {
 	/**
 		`finished` signal.
-		
-		Emitted when the audio stops playing.
 	**/
 	public var onFinished(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFinished():Signal<Void->Void> {
@@ -67,7 +65,7 @@ extern class AudioStreamPlayer3D extends godot.Spatial {
 	public var emissionAngleEnabled:Bool;
 
 	/**		
-		Areas in which this sound plays.
+		Determines which `godot.Area` layers affect the sound for reverb and audio bus effects. Areas can be used to redirect `godot.AudioStream`s so that they play in a certain audio bus. An example of how you might use this is making a "water" area so that sounds played in the water are redirected through an audio bus to make them sound like they are being played underwater.
 	**/
 	@:native("AreaMask")
 	public var areaMask:UInt;

--- a/godot/BakedLightmap.hx
+++ b/godot/BakedLightmap.hx
@@ -7,6 +7,8 @@ import cs.system.*;
 /**
 Baked lightmaps are an alternative workflow for adding indirect (or baked) lighting to a scene. Unlike the `godot.GIProbe` approach, baked lightmaps work fine on low-end PCs and mobile devices as they consume almost no resources in run-time.
 
+Procedural generation: Lightmap baking functionality is only available in the editor. This means `godot.BakedLightmap` is not suited to procedurally generated or user-built levels. For procedurally generated or user-built levels, use `godot.GIProbe` instead.
+
 Note: Due to how lightmaps work, most properties only have a visible effect once lightmaps are baked again.
 **/
 @:libType
@@ -27,7 +29,7 @@ extern class BakedLightmap extends godot.VisualInstance {
 	public var imagePath:std.String;
 
 	/**		
-		Bias value to reduce the amount of light proagation in the captured octree.
+		Bias value to reduce the amount of light propagation in the captured octree.
 	**/
 	@:native("CapturePropagation")
 	public var capturePropagation:Single;
@@ -145,7 +147,7 @@ extern class BakedLightmap extends godot.VisualInstance {
 	public var bounces:Int;
 
 	/**		
-		Determines the amount of samples per texel used in indrect light baking. The amount of samples for each quality level can be configured in the project settings.
+		Determines the amount of samples per texel used in indirect light baking. The amount of samples for each quality level can be configured in the project settings.
 	**/
 	@:native("Quality")
 	public var quality:godot.BakedLightmap_BakeQuality;

--- a/godot/BaseButton.hx
+++ b/godot/BaseButton.hx
@@ -14,8 +14,6 @@ BaseButton is the abstract base class for buttons, so it shouldn't be used direc
 extern abstract class BaseButton extends godot.Control {
 	/**
 		`button_down` signal.
-		
-		Emitted when the button starts being held down.
 	**/
 	public var onButtonDown(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onButtonDown():Signal<Void->Void> {
@@ -24,8 +22,6 @@ extern abstract class BaseButton extends godot.Control {
 
 	/**
 		`button_up` signal.
-		
-		Emitted when the button stops being held down.
 	**/
 	public var onButtonUp(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onButtonUp():Signal<Void->Void> {
@@ -34,9 +30,6 @@ extern abstract class BaseButton extends godot.Control {
 
 	/**
 		`pressed` signal.
-		
-		Emitted when the button is toggled or pressed. This is on `onButtonDown` if `actionMode` is `ACTION_MODE_BUTTON_PRESS` and on `onButtonUp` otherwise.
-		If you need to know the button's pressed state (and `toggleMode` is active), use `onToggled` instead.
 	**/
 	public var onPressed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPressed():Signal<Void->Void> {
@@ -45,8 +38,6 @@ extern abstract class BaseButton extends godot.Control {
 
 	/**
 		`toggled` signal.
-		
-		Emitted when the button was just toggled between pressed and normal states (only if `toggleMode` is active). The new state is contained in the `button_pressed` argument.
 	**/
 	public var onToggled(get, never):Signal<(buttonPressed:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onToggled():Signal<(buttonPressed:Bool)->Void> {

--- a/godot/Button.hx
+++ b/godot/Button.hx
@@ -59,6 +59,8 @@ extern class Button extends godot.BaseButton {
 
 	/**		
 		Button's icon, if text is present the icon will be placed before the text.
+		
+		To edit margin and spacing of the icon, use `hseparation` theme property of `godot.Button` and `content_margin_*` properties of the used `godot.StyleBox`es.
 	**/
 	@:native("Icon")
 	public var icon:godot.Texture;

--- a/godot/ButtonGroup.hx
+++ b/godot/ButtonGroup.hx
@@ -16,8 +16,6 @@ Group of `godot.Button`. All direct and indirect children buttons become radios.
 extern class ButtonGroup extends godot.Resource {
 	/**
 		`pressed` signal.
-		
-		Emitted when one of the buttons of the group is pressed.
 	**/
 	public var onPressed(get, never):Signal<(button:godot.Object)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPressed():Signal<(button:godot.Object)->Void> {

--- a/godot/CPUParticles.hx
+++ b/godot/CPUParticles.hx
@@ -223,7 +223,7 @@ extern class CPUParticles extends godot.GeometryInstance {
 	public var angularVelocityRandom:Single;
 
 	/**		
-		Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
+		Initial angular velocity applied to each particle in degrees per second. Sets the speed of rotation of the particle.
 	**/
 	@:native("AngularVelocity")
 	public var angularVelocity:Single;

--- a/godot/CPUParticles2D.hx
+++ b/godot/CPUParticles2D.hx
@@ -221,7 +221,7 @@ extern class CPUParticles2D extends godot.Node2D {
 	public var angularVelocityRandom:Single;
 
 	/**		
-		Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
+		Initial angular velocity applied to each particle in degrees per second. Sets the speed of rotation of the particle.
 	**/
 	@:native("AngularVelocity")
 	public var angularVelocity:Single;

--- a/godot/CSGBox.hx
+++ b/godot/CSGBox.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 This node allows you to create a box for use with the CSG system.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative

--- a/godot/CSGCombiner.hx
+++ b/godot/CSGCombiner.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 For complex arrangements of shapes, it is sometimes needed to add structure to your CSG nodes. The CSGCombiner node allows you to create this structure. The node encapsulates the result of the CSG operations of its children. In this way, it is possible to do operations on one set of shapes that are children of one CSGCombiner node, and a set of separate operations on a second set of shapes that are children of a second CSGCombiner node, and then do an operation that takes the two end results as its input to create the final shape.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative

--- a/godot/CSGCylinder.hx
+++ b/godot/CSGCylinder.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 This node allows you to create a cylinder (or cone) for use with the CSG system.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative

--- a/godot/CSGMesh.hx
+++ b/godot/CSGMesh.hx
@@ -5,7 +5,9 @@ package godot;
 import cs.system.*;
 
 /**
-This CSG node allows you to use any mesh resource as a CSG shape, provided it is closed, does not self-intersect, does not contain internal faces and has no edges that connect to more then two faces.
+This CSG node allows you to use any mesh resource as a CSG shape, provided it is closed, does not self-intersect, does not contain internal faces and has no edges that connect to more than two faces. See also `godot.CSGPolygon` for drawing 2D extruded polygons to be used as CSG nodes.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative

--- a/godot/CSGPolygon.hx
+++ b/godot/CSGPolygon.hx
@@ -5,7 +5,9 @@ package godot;
 import cs.system.*;
 
 /**
-An array of 2D points is extruded to quickly and easily create a variety of 3D meshes.
+An array of 2D points is extruded to quickly and easily create a variety of 3D meshes. See also `godot.CSGMesh` for using 3D meshes as CSG nodes.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative
@@ -103,7 +105,9 @@ extern class CSGPolygon extends godot.CSGPrimitive {
 	public var mode:godot.CSGPolygon_ModeEnum;
 
 	/**		
-		The point array that defines the 2D polygon that is extruded.
+		The point array that defines the 2D polygon that is extruded. This can be a convex or concave polygon with 3 or more points. The polygon must not have any intersecting edges. Otherwise, triangulation will fail and no mesh will be generated.
+		
+		Note: If only 1 or 2 points are defined in `godot.CSGPolygon.polygon`, no mesh will be generated.
 	**/
 	@:native("Polygon")
 	public var polygon:cs.NativeArray<godot.Vector2>;

--- a/godot/CSGPrimitive.hx
+++ b/godot/CSGPrimitive.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 Parent class for various CSG primitives. It contains code and functionality that is common between them. It cannot be used directly. Instead use one of the various classes that inherit from it.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative

--- a/godot/CSGShape.hx
+++ b/godot/CSGShape.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 This is the CSG base class that provides CSG operation support to the various CSG nodes in Godot.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative

--- a/godot/CSGSphere.hx
+++ b/godot/CSGSphere.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 This node allows you to create a sphere for use with the CSG system.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative

--- a/godot/CSGTorus.hx
+++ b/godot/CSGTorus.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 This node allows you to create a torus for use with the CSG system.
+
+Note: CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a `godot.MeshInstance` with a `godot.PrimitiveMesh`. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 **/
 @:libType
 @:csNative

--- a/godot/Camera.hx
+++ b/godot/Camera.hx
@@ -106,7 +106,7 @@ extern class Camera extends godot.Spatial {
 	public function new():Void;
 
 	/**		
-		Returns a normal vector in world space, that is the result of projecting a point on the `godot.Viewport` rectangle by the camera projection. This is useful for casting rays in the form of (origin, normal) for object intersection or picking.
+		Returns a normal vector in world space, that is the result of projecting a point on the `godot.Viewport` rectangle by the inverse camera projection. This is useful for casting rays in the form of (origin, normal) for object intersection or picking.
 	**/
 	@:native("ProjectRayNormal")
 	public function projectRayNormal(screenPoint:godot.Vector2):godot.Vector3;
@@ -118,7 +118,7 @@ extern class Camera extends godot.Spatial {
 	public function projectLocalRayNormal(screenPoint:godot.Vector2):godot.Vector3;
 
 	/**		
-		Returns a 3D position in world space, that is the result of projecting a point on the `godot.Viewport` rectangle by the camera projection. This is useful for casting rays in the form of (origin, normal) for object intersection or picking.
+		Returns a 3D position in world space, that is the result of projecting a point on the `godot.Viewport` rectangle by the inverse camera projection. This is useful for casting rays in the form of (origin, normal) for object intersection or picking.
 	**/
 	@:native("ProjectRayOrigin")
 	public function projectRayOrigin(screenPoint:godot.Vector2):godot.Vector3;

--- a/godot/CameraFeed.hx
+++ b/godot/CameraFeed.hx
@@ -5,7 +5,7 @@ package godot;
 import cs.system.*;
 
 /**
-A camera feed gives you access to a single physical camera attached to your device. When enabled, Godot will start capturing frames from the camera which can then be used.
+A camera feed gives you access to a single physical camera attached to your device. When enabled, Godot will start capturing frames from the camera which can then be used. See also `godot.CameraServer`.
 
 Note: Many cameras will return YCbCr images which are split into two textures and need to be combined in a shader. Godot does this automatically for you if you set the environment to show the camera image in the background.
 **/

--- a/godot/CameraServer.hx
+++ b/godot/CameraServer.hx
@@ -8,6 +8,8 @@ import cs.system.*;
 The `godot.CameraServer` keeps track of different cameras accessible in Godot. These are external cameras such as webcams or the cameras on your phone.
 
 It is notably used to provide AR modules with a video feed from the camera.
+
+Note: This class is currently only implemented on macOS and iOS. On other platforms, no `godot.CameraFeed`s will be available.
 **/
 @:libType
 @:csNative
@@ -16,8 +18,6 @@ It is notably used to provide AR modules with a video feed from the camera.
 extern class CameraServer {
 	/**
 		`camera_feed_added` signal.
-		
-		Emitted when a `CameraFeed` is added (e.g. webcam is plugged in).
 	**/
 	public static var onCameraFeedAdded(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onCameraFeedAdded():Signal<(id:Int)->Void> {
@@ -26,8 +26,6 @@ extern class CameraServer {
 
 	/**
 		`camera_feed_removed` signal.
-		
-		Emitted when a `CameraFeed` is removed (e.g. webcam is unplugged).
 	**/
 	public static var onCameraFeedRemoved(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onCameraFeedRemoved():Signal<(id:Int)->Void> {
@@ -38,7 +36,7 @@ extern class CameraServer {
 	public static var SINGLETON(default, never):godot.Object;
 
 	/**		
-		Returns the `godot.CameraFeed` with this id.
+		Returns the `godot.CameraFeed` corresponding to the camera with the given `index`.
 	**/
 	@:native("GetFeed")
 	public static function getFeed(index:Int):godot.CameraFeed;
@@ -56,13 +54,13 @@ extern class CameraServer {
 	public static function feeds():godot.collections.Array;
 
 	/**		
-		Adds a camera feed to the camera server.
+		Adds the camera `feed` to the camera server.
 	**/
 	@:native("AddFeed")
 	public static function addFeed(feed:godot.CameraFeed):Void;
 
 	/**		
-		Removes a `godot.CameraFeed`.
+		Removes the specified camera `feed`.
 	**/
 	@:native("RemoveFeed")
 	public static function removeFeed(feed:godot.CameraFeed):Void;

--- a/godot/CameraServer_FeedImage.hx
+++ b/godot/CameraServer_FeedImage.hx
@@ -11,7 +11,7 @@ extern enum CameraServer_FeedImage {
 	RgbaImage;
 
 	/**		
-		The YCbCr camera image.
+		The [https://en.wikipedia.org/wiki/YCbCr](YCbCr) camera image.
 	**/
 	YcbcrImage;
 

--- a/godot/CanvasItem.hx
+++ b/godot/CanvasItem.hx
@@ -24,8 +24,6 @@ Note: Unless otherwise specified, all methods that have angle parameters must ha
 extern abstract class CanvasItem extends godot.Node {
 	/**
 		`draw` signal.
-		
-		Emitted when the `CanvasItem` must redraw. This can only be connected realtime, as deferred will not allow drawing.
 	**/
 	public var onDraw(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onDraw():Signal<Void->Void> {
@@ -34,8 +32,6 @@ extern abstract class CanvasItem extends godot.Node {
 
 	/**
 		`hide` signal.
-		
-		Emitted when becoming hidden.
 	**/
 	public var onHide(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onHide():Signal<Void->Void> {
@@ -44,8 +40,6 @@ extern abstract class CanvasItem extends godot.Node {
 
 	/**
 		`item_rect_changed` signal.
-		
-		Emitted when the item's `Rect2` boundaries (position or size) have changed, or when an action is taking place that may have impacted these boundaries (e.g. changing `sprite.texture`).
 	**/
 	public var onItemRectChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemRectChanged():Signal<Void->Void> {
@@ -54,8 +48,6 @@ extern abstract class CanvasItem extends godot.Node {
 
 	/**
 		`visibility_changed` signal.
-		
-		Emitted when the visibility (hidden/visible) changes.
 	**/
 	public var onVisibilityChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onVisibilityChanged():Signal<Void->Void> {
@@ -167,13 +159,13 @@ extern abstract class CanvasItem extends godot.Node {
 	public function isVisibleInTree():Bool;
 
 	/**		
-		Show the `godot.CanvasItem` if it's currently hidden. For controls that inherit `godot.Popup`, the correct way to make them visible is to call one of the multiple `popup*()` functions instead.
+		Show the `godot.CanvasItem` if it's currently hidden. This is equivalent to setting `godot.CanvasItem.visible` to `true`. For controls that inherit `godot.Popup`, the correct way to make them visible is to call one of the multiple `popup*()` functions instead.
 	**/
 	@:native("Show")
 	public function show():Void;
 
 	/**		
-		Hide the `godot.CanvasItem` if it's currently visible.
+		Hide the `godot.CanvasItem` if it's currently visible. This is equivalent to setting `godot.CanvasItem.visible` to `false`.
 	**/
 	@:native("Hide")
 	public function hide():Void;
@@ -185,7 +177,7 @@ extern abstract class CanvasItem extends godot.Node {
 	public function update():Void;
 
 	/**		
-		If `enable` is `true`, the node won't inherit its transform from parent canvas items.
+		If `enable` is `true`, this `godot.CanvasItem` will not inherit its transform from parent `godot.CanvasItem`s. Its draw order will also be changed to make it draw on top of other `godot.CanvasItem`s that are not set as top-level. The `godot.CanvasItem` will effectively act as if it was placed as a child of a bare `godot.Node`. See also `godot.CanvasItem.isSetAsToplevel`.
 	**/
 	@:native("SetAsToplevel")
 	public function setAsToplevel(enable:Bool):Void;
@@ -222,25 +214,41 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased.
+		Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased. See also `godot.CanvasItem.drawMultiline` and `godot.CanvasItem.drawPolyline`.
+		
+		Note: Line drawing is not accelerated by batching if `antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawLine")
 	public function drawLine(from:godot.Vector2, to:godot.Vector2, color:godot.Color, ?width:Single, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased.
+		Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased. See also `godot.CanvasItem.drawMultiline` and `godot.CanvasItem.drawPolyline`.
+		
+		Note: Line drawing is not accelerated by batching if `antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawLine")
 	public overload function drawLine(from:godot.Vector2, to:godot.Vector2, color:godot.Color):Void;
 
 	/**		
-		Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased.
+		Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased. See also `godot.CanvasItem.drawMultiline` and `godot.CanvasItem.drawPolyline`.
+		
+		Note: Line drawing is not accelerated by batching if `antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawLine")
 	public overload function drawLine(from:godot.Vector2, to:godot.Vector2, color:godot.Color, width:Single):Void;
 
 	/**		
-		Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased.
+		Draws a line from a 2D point to another, with a given color and width. It can be optionally antialiased. See also `godot.CanvasItem.drawMultiline` and `godot.CanvasItem.drawPolyline`.
+		
+		Note: Line drawing is not accelerated by batching if `antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawLine")
 	public overload function drawLine(from:godot.Vector2, to:godot.Vector2, color:godot.Color, width:Single, antialiased:Bool):Void;
@@ -248,25 +256,33 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws interconnected line segments with a uniform `color` and `width` and optional antialiasing.
+		Draws interconnected line segments with a uniform `color` and `width` and optional antialiasing. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw disconnected lines, use `godot.CanvasItem.drawMultiline` instead. See also `godot.CanvasItem.drawPolygon`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawPolyline")
 	public function drawPolyline(points:std.Array<godot.Vector2>, color:godot.Color, ?width:Single, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws interconnected line segments with a uniform `color` and `width` and optional antialiasing.
+		Draws interconnected line segments with a uniform `color` and `width` and optional antialiasing. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw disconnected lines, use `godot.CanvasItem.drawMultiline` instead. See also `godot.CanvasItem.drawPolygon`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawPolyline")
 	public overload function drawPolyline(points:HaxeArray<godot.Vector2>, color:godot.Color):Void;
 
 	/**		
-		Draws interconnected line segments with a uniform `color` and `width` and optional antialiasing.
+		Draws interconnected line segments with a uniform `color` and `width` and optional antialiasing. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw disconnected lines, use `godot.CanvasItem.drawMultiline` instead. See also `godot.CanvasItem.drawPolygon`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawPolyline")
 	public overload function drawPolyline(points:HaxeArray<godot.Vector2>, color:godot.Color, width:Single):Void;
 
 	/**		
-		Draws interconnected line segments with a uniform `color` and `width` and optional antialiasing.
+		Draws interconnected line segments with a uniform `color` and `width` and optional antialiasing. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw disconnected lines, use `godot.CanvasItem.drawMultiline` instead. See also `godot.CanvasItem.drawPolygon`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawPolyline")
 	public overload function drawPolyline(points:HaxeArray<godot.Vector2>, color:godot.Color, width:Single, antialiased:Bool):Void;
@@ -274,25 +290,33 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws interconnected line segments with a uniform `width`, segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between `points` and `colors`.
+		Draws interconnected line segments with a uniform `width` and segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between `points` and `colors`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw disconnected lines, use `godot.CanvasItem.drawMultilineColors` instead. See also `godot.CanvasItem.drawPolygon`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawPolylineColors")
 	public function drawPolylineColors(points:std.Array<godot.Vector2>, colors:std.Array<godot.Color>, ?width:Single, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws interconnected line segments with a uniform `width`, segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between `points` and `colors`.
+		Draws interconnected line segments with a uniform `width` and segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between `points` and `colors`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw disconnected lines, use `godot.CanvasItem.drawMultilineColors` instead. See also `godot.CanvasItem.drawPolygon`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawPolylineColors")
 	public overload function drawPolylineColors(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>):Void;
 
 	/**		
-		Draws interconnected line segments with a uniform `width`, segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between `points` and `colors`.
+		Draws interconnected line segments with a uniform `width` and segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between `points` and `colors`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw disconnected lines, use `godot.CanvasItem.drawMultilineColors` instead. See also `godot.CanvasItem.drawPolygon`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawPolylineColors")
 	public overload function drawPolylineColors(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, width:Single):Void;
 
 	/**		
-		Draws interconnected line segments with a uniform `width`, segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between `points` and `colors`.
+		Draws interconnected line segments with a uniform `width` and segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between `points` and `colors`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw disconnected lines, use `godot.CanvasItem.drawMultilineColors` instead. See also `godot.CanvasItem.drawPolygon`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawPolylineColors")
 	public overload function drawPolylineColors(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, width:Single, antialiased:Bool):Void;
@@ -300,25 +324,41 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws an arc between the given angles. The larger the value of `point_count`, the smoother the curve.
+		Draws a unfilled arc between the given angles. The larger the value of `point_count`, the smoother the curve. See also `godot.CanvasItem.drawCircle`.
+		
+		Note: Line drawing is not accelerated by batching if `antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedRegularPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawArc")
 	public function drawArc(center:godot.Vector2, radius:Single, startAngle:Single, endAngle:Single, pointCount:Int, color:godot.Color, ?width:Single, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws an arc between the given angles. The larger the value of `point_count`, the smoother the curve.
+		Draws a unfilled arc between the given angles. The larger the value of `point_count`, the smoother the curve. See also `godot.CanvasItem.drawCircle`.
+		
+		Note: Line drawing is not accelerated by batching if `antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedRegularPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawArc")
 	public overload function drawArc(center:godot.Vector2, radius:Single, startAngle:Single, endAngle:Single, pointCount:Int, color:godot.Color):Void;
 
 	/**		
-		Draws an arc between the given angles. The larger the value of `point_count`, the smoother the curve.
+		Draws a unfilled arc between the given angles. The larger the value of `point_count`, the smoother the curve. See also `godot.CanvasItem.drawCircle`.
+		
+		Note: Line drawing is not accelerated by batching if `antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedRegularPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawArc")
 	public overload function drawArc(center:godot.Vector2, radius:Single, startAngle:Single, endAngle:Single, pointCount:Int, color:godot.Color, width:Single):Void;
 
 	/**		
-		Draws an arc between the given angles. The larger the value of `point_count`, the smoother the curve.
+		Draws a unfilled arc between the given angles. The larger the value of `point_count`, the smoother the curve. See also `godot.CanvasItem.drawCircle`.
+		
+		Note: Line drawing is not accelerated by batching if `antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedRegularPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawArc")
 	public overload function drawArc(center:godot.Vector2, radius:Single, startAngle:Single, endAngle:Single, pointCount:Int, color:godot.Color, width:Single, antialiased:Bool):Void;
@@ -326,33 +366,33 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws multiple, parallel lines with a uniform `color`.
+		Draws multiple disconnected lines with a uniform `color`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw interconnected lines, use `godot.CanvasItem.drawPolyline` instead.
 		
-		Note: `width` and `antialiased` are currently not implemented and have no effect.
+		Note: `width` and `antialiased` are currently not implemented and have no effect. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawMultiline")
 	public function drawMultiline(points:std.Array<godot.Vector2>, color:godot.Color, ?width:Single, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws multiple, parallel lines with a uniform `color`.
+		Draws multiple disconnected lines with a uniform `color`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw interconnected lines, use `godot.CanvasItem.drawPolyline` instead.
 		
-		Note: `width` and `antialiased` are currently not implemented and have no effect.
+		Note: `width` and `antialiased` are currently not implemented and have no effect. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawMultiline")
 	public overload function drawMultiline(points:HaxeArray<godot.Vector2>, color:godot.Color):Void;
 
 	/**		
-		Draws multiple, parallel lines with a uniform `color`.
+		Draws multiple disconnected lines with a uniform `color`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw interconnected lines, use `godot.CanvasItem.drawPolyline` instead.
 		
-		Note: `width` and `antialiased` are currently not implemented and have no effect.
+		Note: `width` and `antialiased` are currently not implemented and have no effect. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawMultiline")
 	public overload function drawMultiline(points:HaxeArray<godot.Vector2>, color:godot.Color, width:Single):Void;
 
 	/**		
-		Draws multiple, parallel lines with a uniform `color`.
+		Draws multiple disconnected lines with a uniform `color`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw interconnected lines, use `godot.CanvasItem.drawPolyline` instead.
 		
-		Note: `width` and `antialiased` are currently not implemented and have no effect.
+		Note: `width` and `antialiased` are currently not implemented and have no effect. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawMultiline")
 	public overload function drawMultiline(points:HaxeArray<godot.Vector2>, color:godot.Color, width:Single, antialiased:Bool):Void;
@@ -360,33 +400,33 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws multiple, parallel lines with a uniform `width` and segment-by-segment coloring. Colors assigned to line segments match by index between `points` and `colors`.
+		Draws multiple disconnected lines with a uniform `width` and segment-by-segment coloring. Colors assigned to line segments match by index between `points` and `colors`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw interconnected lines, use `godot.CanvasItem.drawPolylineColors` instead.
 		
-		Note: `width` and `antialiased` are currently not implemented and have no effect.
+		Note: `width` and `antialiased` are currently not implemented and have no effect. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawMultilineColors")
 	public function drawMultilineColors(points:std.Array<godot.Vector2>, colors:std.Array<godot.Color>, ?width:Single, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws multiple, parallel lines with a uniform `width` and segment-by-segment coloring. Colors assigned to line segments match by index between `points` and `colors`.
+		Draws multiple disconnected lines with a uniform `width` and segment-by-segment coloring. Colors assigned to line segments match by index between `points` and `colors`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw interconnected lines, use `godot.CanvasItem.drawPolylineColors` instead.
 		
-		Note: `width` and `antialiased` are currently not implemented and have no effect.
+		Note: `width` and `antialiased` are currently not implemented and have no effect. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawMultilineColors")
 	public overload function drawMultilineColors(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>):Void;
 
 	/**		
-		Draws multiple, parallel lines with a uniform `width` and segment-by-segment coloring. Colors assigned to line segments match by index between `points` and `colors`.
+		Draws multiple disconnected lines with a uniform `width` and segment-by-segment coloring. Colors assigned to line segments match by index between `points` and `colors`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw interconnected lines, use `godot.CanvasItem.drawPolylineColors` instead.
 		
-		Note: `width` and `antialiased` are currently not implemented and have no effect.
+		Note: `width` and `antialiased` are currently not implemented and have no effect. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawMultilineColors")
 	public overload function drawMultilineColors(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, width:Single):Void;
 
 	/**		
-		Draws multiple, parallel lines with a uniform `width` and segment-by-segment coloring. Colors assigned to line segments match by index between `points` and `colors`.
+		Draws multiple disconnected lines with a uniform `width` and segment-by-segment coloring. Colors assigned to line segments match by index between `points` and `colors`. When drawing large amounts of lines, this is faster than using individual `godot.CanvasItem.drawLine` calls. To draw interconnected lines, use `godot.CanvasItem.drawPolylineColors` instead.
 		
-		Note: `width` and `antialiased` are currently not implemented and have no effect.
+		Note: `width` and `antialiased` are currently not implemented and have no effect. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("DrawMultilineColors")
 	public overload function drawMultilineColors(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, width:Single, antialiased:Bool):Void;
@@ -394,48 +434,60 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will be antialiased.
+		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will attempt to perform antialiasing using OpenGL line smoothing.
 		
 		Note: `width` and `antialiased` are only effective if `filled` is `false`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawRect")
 	public function drawRect(rect:godot.Rect2, color:godot.Color, ?filled:Bool, ?width:Single, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will be antialiased.
+		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will attempt to perform antialiasing using OpenGL line smoothing.
 		
 		Note: `width` and `antialiased` are only effective if `filled` is `false`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawRect")
 	public overload function drawRect(rect:godot.Rect2, color:godot.Color):Void;
 
 	/**		
-		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will be antialiased.
+		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will attempt to perform antialiasing using OpenGL line smoothing.
 		
 		Note: `width` and `antialiased` are only effective if `filled` is `false`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawRect")
 	public overload function drawRect(rect:godot.Rect2, color:godot.Color, filled:Bool):Void;
 
 	/**		
-		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will be antialiased.
+		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will attempt to perform antialiasing using OpenGL line smoothing.
 		
 		Note: `width` and `antialiased` are only effective if `filled` is `false`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawRect")
 	public overload function drawRect(rect:godot.Rect2, color:godot.Color, filled:Bool, width:Single):Void;
 
 	/**		
-		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will be antialiased.
+		Draws a rectangle. If `filled` is `true`, the rectangle will be filled with the `color` specified. If `filled` is `false`, the rectangle will be drawn as a stroke with the `color` and `width` specified. If `antialiased` is `true`, the lines will attempt to perform antialiasing using OpenGL line smoothing.
 		
 		Note: `width` and `antialiased` are only effective if `filled` is `false`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawRect")
 	public overload function drawRect(rect:godot.Rect2, color:godot.Color, filled:Bool, width:Single, antialiased:Bool):Void;
 	#end
 
 	/**		
-		Draws a colored circle.
+		Draws a colored, filled circle. See also `godot.CanvasItem.drawArc`, `godot.CanvasItem.drawPolyline` and `godot.CanvasItem.drawPolygon`.
+		
+		Note: Built-in antialiasing is not provided for `godot.CanvasItem.drawCircle`. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedRegularPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("DrawCircle")
 	public function drawCircle(position:godot.Vector2, radius:Single, color:godot.Color):Void;
@@ -574,31 +626,31 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle and 4 points for a quad.
+		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle, and 4 points for a quad. If 0 points or more than 4 points are specified, nothing will be drawn and an error message will be printed. See also `godot.CanvasItem.drawLine`, `godot.CanvasItem.drawPolyline`, `godot.CanvasItem.drawPolygon`, and `godot.CanvasItem.drawRect`.
 	**/
 	@:native("DrawPrimitive")
 	public function drawPrimitive(points:std.Array<godot.Vector2>, colors:std.Array<godot.Color>, uvs:std.Array<godot.Vector2>, ?texture:godot.Texture, ?width:Single, ?normalMap:godot.Texture):Void;
 	#else
 	/**		
-		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle and 4 points for a quad.
+		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle, and 4 points for a quad. If 0 points or more than 4 points are specified, nothing will be drawn and an error message will be printed. See also `godot.CanvasItem.drawLine`, `godot.CanvasItem.drawPolyline`, `godot.CanvasItem.drawPolygon`, and `godot.CanvasItem.drawRect`.
 	**/
 	@:native("DrawPrimitive")
 	public overload function drawPrimitive(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, uvs:HaxeArray<godot.Vector2>):Void;
 
 	/**		
-		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle and 4 points for a quad.
+		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle, and 4 points for a quad. If 0 points or more than 4 points are specified, nothing will be drawn and an error message will be printed. See also `godot.CanvasItem.drawLine`, `godot.CanvasItem.drawPolyline`, `godot.CanvasItem.drawPolygon`, and `godot.CanvasItem.drawRect`.
 	**/
 	@:native("DrawPrimitive")
 	public overload function drawPrimitive(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, uvs:HaxeArray<godot.Vector2>, texture:godot.Texture):Void;
 
 	/**		
-		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle and 4 points for a quad.
+		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle, and 4 points for a quad. If 0 points or more than 4 points are specified, nothing will be drawn and an error message will be printed. See also `godot.CanvasItem.drawLine`, `godot.CanvasItem.drawPolyline`, `godot.CanvasItem.drawPolygon`, and `godot.CanvasItem.drawRect`.
 	**/
 	@:native("DrawPrimitive")
 	public overload function drawPrimitive(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, uvs:HaxeArray<godot.Vector2>, texture:godot.Texture, width:Single):Void;
 
 	/**		
-		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle and 4 points for a quad.
+		Draws a custom primitive. 1 point for a point, 2 points for a line, 3 points for a triangle, and 4 points for a quad. If 0 points or more than 4 points are specified, nothing will be drawn and an error message will be printed. See also `godot.CanvasItem.drawLine`, `godot.CanvasItem.drawPolyline`, `godot.CanvasItem.drawPolygon`, and `godot.CanvasItem.drawRect`.
 	**/
 	@:native("DrawPrimitive")
 	public overload function drawPrimitive(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, uvs:HaxeArray<godot.Vector2>, texture:godot.Texture, width:Single, normalMap:godot.Texture):Void;
@@ -606,7 +658,9 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws a polygon of any amount of points, convex or concave.
+		Draws a solid polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawColoredPolygon`, each point's color can be changed individually. See also `godot.CanvasItem.drawPolyline` and `godot.CanvasItem.drawPolylineColors`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -614,7 +668,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public function drawPolygon(points:std.Array<godot.Vector2>, colors:std.Array<godot.Color>, ?uvs:std.Array<godot.Vector2>, ?texture:godot.Texture, ?normalMap:godot.Texture, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws a polygon of any amount of points, convex or concave.
+		Draws a solid polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawColoredPolygon`, each point's color can be changed individually. See also `godot.CanvasItem.drawPolyline` and `godot.CanvasItem.drawPolylineColors`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -622,7 +678,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public overload function drawPolygon(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>):Void;
 
 	/**		
-		Draws a polygon of any amount of points, convex or concave.
+		Draws a solid polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawColoredPolygon`, each point's color can be changed individually. See also `godot.CanvasItem.drawPolyline` and `godot.CanvasItem.drawPolylineColors`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -630,7 +688,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public overload function drawPolygon(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, uvs:HaxeArray<godot.Vector2>):Void;
 
 	/**		
-		Draws a polygon of any amount of points, convex or concave.
+		Draws a solid polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawColoredPolygon`, each point's color can be changed individually. See also `godot.CanvasItem.drawPolyline` and `godot.CanvasItem.drawPolylineColors`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -638,7 +698,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public overload function drawPolygon(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, uvs:HaxeArray<godot.Vector2>, texture:godot.Texture):Void;
 
 	/**		
-		Draws a polygon of any amount of points, convex or concave.
+		Draws a solid polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawColoredPolygon`, each point's color can be changed individually. See also `godot.CanvasItem.drawPolyline` and `godot.CanvasItem.drawPolylineColors`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -646,7 +708,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public overload function drawPolygon(points:HaxeArray<godot.Vector2>, colors:HaxeArray<godot.Color>, uvs:HaxeArray<godot.Vector2>, texture:godot.Texture, normalMap:godot.Texture):Void;
 
 	/**		
-		Draws a polygon of any amount of points, convex or concave.
+		Draws a solid polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawColoredPolygon`, each point's color can be changed individually. See also `godot.CanvasItem.drawPolyline` and `godot.CanvasItem.drawPolylineColors`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -656,7 +720,9 @@ extern abstract class CanvasItem extends godot.Node {
 
 	#if doc_gen
 	/**		
-		Draws a colored polygon of any amount of points, convex or concave.
+		Draws a colored polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawPolygon`, a single color must be specified for the whole polygon.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -664,7 +730,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public function drawColoredPolygon(points:std.Array<godot.Vector2>, color:godot.Color, ?uvs:std.Array<godot.Vector2>, ?texture:godot.Texture, ?normalMap:godot.Texture, ?antialiased:Bool):Void;
 	#else
 	/**		
-		Draws a colored polygon of any amount of points, convex or concave.
+		Draws a colored polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawPolygon`, a single color must be specified for the whole polygon.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -672,7 +740,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public overload function drawColoredPolygon(points:HaxeArray<godot.Vector2>, color:godot.Color):Void;
 
 	/**		
-		Draws a colored polygon of any amount of points, convex or concave.
+		Draws a colored polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawPolygon`, a single color must be specified for the whole polygon.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -680,7 +750,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public overload function drawColoredPolygon(points:HaxeArray<godot.Vector2>, color:godot.Color, uvs:HaxeArray<godot.Vector2>):Void;
 
 	/**		
-		Draws a colored polygon of any amount of points, convex or concave.
+		Draws a colored polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawPolygon`, a single color must be specified for the whole polygon.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -688,7 +760,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public overload function drawColoredPolygon(points:HaxeArray<godot.Vector2>, color:godot.Color, uvs:HaxeArray<godot.Vector2>, texture:godot.Texture):Void;
 
 	/**		
-		Draws a colored polygon of any amount of points, convex or concave.
+		Draws a colored polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawPolygon`, a single color must be specified for the whole polygon.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/
@@ -696,7 +770,9 @@ extern abstract class CanvasItem extends godot.Node {
 	public overload function drawColoredPolygon(points:HaxeArray<godot.Vector2>, color:godot.Color, uvs:HaxeArray<godot.Vector2>, texture:godot.Texture, normalMap:godot.Texture):Void;
 
 	/**		
-		Draws a colored polygon of any amount of points, convex or concave.
+		Draws a colored polygon of any amount of points, convex or concave. Unlike `godot.CanvasItem.drawPolygon`, a single color must be specified for the whole polygon.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 		
 		@param uvs If the parameter is null, then the default value is Array.Empty&lt;Vector2&gt;()
 	**/

--- a/godot/CharFXTransform.hx
+++ b/godot/CharFXTransform.hx
@@ -67,13 +67,13 @@ extern class CharFXTransform extends godot.Reference {
 	public var elapsedTime:Single;
 
 	/**		
-		The index of the current character (starting from 0). Setting this property won't affect drawing.
+		The index of the current character (starting from 0) for the `godot.RichTextLabel`'s BBCode text. Setting this property won't affect drawing.
 	**/
 	@:native("AbsoluteIndex")
 	public var absoluteIndex:cs.types.UInt64;
 
 	/**		
-		The index of the current character (starting from 0). Setting this property won't affect drawing.
+		The index of the current character (starting from 0) for this `godot.RichTextEffect` custom block. Setting this property won't affect drawing.
 	**/
 	@:native("RelativeIndex")
 	public var relativeIndex:cs.types.UInt64;

--- a/godot/CollisionObject.hx
+++ b/godot/CollisionObject.hx
@@ -14,8 +14,6 @@ CollisionObject is the base class for physics objects. It can hold any number of
 extern abstract class CollisionObject extends godot.Spatial {
 	/**
 		`input_event` signal.
-		
-		Emitted when the object receives an unhandled `InputEvent`. `position` is the location in world space of the mouse pointer on the surface of the shape with index `shape_idx` and `normal` is the normal vector of the surface at that point.
 	**/
 	public var onInputEvent(get, never):Signal<(camera:Node, event:InputEvent, position:Vector3, normal:Vector3, shapeIdx:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onInputEvent():Signal<(camera:Node, event:InputEvent, position:Vector3, normal:Vector3, shapeIdx:Int)->Void> {
@@ -24,8 +22,6 @@ extern abstract class CollisionObject extends godot.Spatial {
 
 	/**
 		`mouse_entered` signal.
-		
-		Emitted when the mouse pointer enters any of this object's shapes.
 	**/
 	public var onMouseEntered(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMouseEntered():Signal<Void->Void> {
@@ -34,8 +30,6 @@ extern abstract class CollisionObject extends godot.Spatial {
 
 	/**
 		`mouse_exited` signal.
-		
-		Emitted when the mouse pointer exits all this object's shapes.
 	**/
 	public var onMouseExited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMouseExited():Signal<Void->Void> {
@@ -49,7 +43,7 @@ extern abstract class CollisionObject extends godot.Spatial {
 	public var inputCaptureOnDrag:Bool;
 
 	/**		
-		If `true`, the `godot.CollisionObject`'s shapes will respond to `godot.RayCast`s.
+		If `true`, this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events. Requires at least one `godot.CollisionObject.collisionLayer` bit to be set.
 	**/
 	@:native("InputRayPickable")
 	public var inputRayPickable:Bool;

--- a/godot/CollisionObject2D.hx
+++ b/godot/CollisionObject2D.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 CollisionObject2D is the base class for 2D physics objects. It can hold any number of 2D collision `godot.Shape2D`s. Each shape must be assigned to a shape owner. The CollisionObject2D can have any number of shape owners. Shape owners are not nodes and do not appear in the editor, but are accessible through code using the `shape_owner_*` methods.
+
+Note: Only collisions between objects within the same canvas (`godot.Viewport` canvas or `godot.CanvasLayer`) are supported. The behavior of collisions between objects in different canvases is undefined.
 **/
 @:libType
 @:csNative
@@ -14,8 +16,6 @@ CollisionObject2D is the base class for 2D physics objects. It can hold any numb
 extern abstract class CollisionObject2D extends godot.Node2D {
 	/**
 		`input_event` signal.
-		
-		Emitted when an input event occurs. Requires `inputPickable` to be `true` and at least one `collision_layer` bit to be set. See `InputEvent` for details.
 	**/
 	public var onInputEvent(get, never):Signal<(viewport:Node, event:InputEvent, shapeIdx:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onInputEvent():Signal<(viewport:Node, event:InputEvent, shapeIdx:Int)->Void> {
@@ -24,8 +24,6 @@ extern abstract class CollisionObject2D extends godot.Node2D {
 
 	/**
 		`mouse_entered` signal.
-		
-		Emitted when the mouse pointer enters any of this object's shapes. Requires `inputPickable` to be `true` and at least one `collision_layer` bit to be set.
 	**/
 	public var onMouseEntered(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMouseEntered():Signal<Void->Void> {
@@ -34,8 +32,6 @@ extern abstract class CollisionObject2D extends godot.Node2D {
 
 	/**
 		`mouse_exited` signal.
-		
-		Emitted when the mouse pointer exits all this object's shapes. Requires `inputPickable` to be `true` and at least one `collision_layer` bit to be set.
 	**/
 	public var onMouseExited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMouseExited():Signal<Void->Void> {
@@ -43,7 +39,7 @@ extern abstract class CollisionObject2D extends godot.Node2D {
 	}
 
 	/**		
-		If `true`, this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events. Requires at least one `collision_layer` bit to be set.
+		If `true`, this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events. Requires at least one `godot.CollisionObject2D.collisionLayer` bit to be set.
 	**/
 	@:native("InputPickable")
 	public var inputPickable:Bool;

--- a/godot/ColorPicker.hx
+++ b/godot/ColorPicker.hx
@@ -16,8 +16,6 @@ Note: This control is the color picker widget itself. You can use a `godot.Color
 extern class ColorPicker extends godot.BoxContainer {
 	/**
 		`color_changed` signal.
-		
-		Emitted when the color is changed.
 	**/
 	public var onColorChanged(get, never):Signal<(color:Color)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onColorChanged():Signal<(color:Color)->Void> {
@@ -26,8 +24,6 @@ extern class ColorPicker extends godot.BoxContainer {
 
 	/**
 		`preset_added` signal.
-		
-		Emitted when a preset is added.
 	**/
 	public var onPresetAdded(get, never):Signal<(color:Color)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPresetAdded():Signal<(color:Color)->Void> {
@@ -36,8 +32,6 @@ extern class ColorPicker extends godot.BoxContainer {
 
 	/**
 		`preset_removed` signal.
-		
-		Emitted when a preset is removed.
 	**/
 	public var onPresetRemoved(get, never):Signal<(color:Color)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPresetRemoved():Signal<(color:Color)->Void> {
@@ -79,7 +73,7 @@ extern class ColorPicker extends godot.BoxContainer {
 	public var hsvMode:Bool;
 
 	/**		
-		If `true`, shows an alpha channel slider (transparency).
+		If `true`, shows an alpha channel slider (opacity).
 	**/
 	@:native("EditAlpha")
 	public var editAlpha:Bool;

--- a/godot/ColorPickerButton.hx
+++ b/godot/ColorPickerButton.hx
@@ -18,8 +18,6 @@ Note: By default, the button may not be wide enough for the color preview swatch
 extern class ColorPickerButton extends godot.Button {
 	/**
 		`color_changed` signal.
-		
-		Emitted when the color changes.
 	**/
 	public var onColorChanged(get, never):Signal<(color:Color)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onColorChanged():Signal<(color:Color)->Void> {
@@ -28,8 +26,6 @@ extern class ColorPickerButton extends godot.Button {
 
 	/**
 		`picker_created` signal.
-		
-		Emitted when the `ColorPicker` is created (the button is pressed for the first time).
 	**/
 	public var onPickerCreated(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPickerCreated():Signal<Void->Void> {
@@ -38,8 +34,6 @@ extern class ColorPickerButton extends godot.Button {
 
 	/**
 		`popup_closed` signal.
-		
-		Emitted when the `ColorPicker` is closed.
 	**/
 	public var onPopupClosed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPopupClosed():Signal<Void->Void> {

--- a/godot/Container.hx
+++ b/godot/Container.hx
@@ -16,8 +16,6 @@ A Control can inherit this to create custom container classes.
 extern class Container extends godot.Control {
 	/**
 		`sort_children` signal.
-		
-		Emitted when sorting the children is needed.
 	**/
 	public var onSortChildren(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSortChildren():Signal<Void->Void> {

--- a/godot/Control.hx
+++ b/godot/Control.hx
@@ -28,8 +28,6 @@ Note: Theme items are not `godot.Object` properties. This means you can't access
 extern class Control extends godot.CanvasItem {
 	/**
 		`focus_entered` signal.
-		
-		Emitted when the node gains keyboard focus.
 	**/
 	public var onFocusEntered(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFocusEntered():Signal<Void->Void> {
@@ -38,8 +36,6 @@ extern class Control extends godot.CanvasItem {
 
 	/**
 		`focus_exited` signal.
-		
-		Emitted when the node loses keyboard focus.
 	**/
 	public var onFocusExited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFocusExited():Signal<Void->Void> {
@@ -48,8 +44,6 @@ extern class Control extends godot.CanvasItem {
 
 	/**
 		`gui_input` signal.
-		
-		Emitted when the node receives an `InputEvent`.
 	**/
 	public var onGuiInput(get, never):Signal<(event:InputEvent)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onGuiInput():Signal<(event:InputEvent)->Void> {
@@ -58,8 +52,6 @@ extern class Control extends godot.CanvasItem {
 
 	/**
 		`minimum_size_changed` signal.
-		
-		Emitted when the node's minimum size changes.
 	**/
 	public var onMinimumSizeChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMinimumSizeChanged():Signal<Void->Void> {
@@ -68,8 +60,6 @@ extern class Control extends godot.CanvasItem {
 
 	/**
 		`modal_closed` signal.
-		
-		Emitted when a modal `Control` is closed. See `showModal`.
 	**/
 	public var onModalClosed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onModalClosed():Signal<Void->Void> {
@@ -78,9 +68,6 @@ extern class Control extends godot.CanvasItem {
 
 	/**
 		`mouse_entered` signal.
-		
-		Emitted when the mouse enters the control's `Rect` area, provided its `mouseFilter` lets the event reach it.
-		`b`Note:`/b` `onMouseEntered` will not be emitted if the mouse enters a child `Control` node before entering the parent's `Rect` area, at least until the mouse is moved to reach the parent's `Rect` area.
 	**/
 	public var onMouseEntered(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMouseEntered():Signal<Void->Void> {
@@ -89,9 +76,6 @@ extern class Control extends godot.CanvasItem {
 
 	/**
 		`mouse_exited` signal.
-		
-		Emitted when the mouse leaves the control's `Rect` area, provided its `mouseFilter` lets the event reach it.
-		`b`Note:`/b` `onMouseExited` will be emitted if the mouse enters a child `Control` node, even if the mouse cursor is still inside the parent's `Rect` area.
 	**/
 	public var onMouseExited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMouseExited():Signal<Void->Void> {
@@ -100,8 +84,6 @@ extern class Control extends godot.CanvasItem {
 
 	/**
 		`resized` signal.
-		
-		Emitted when the control changes size.
 	**/
 	public var onResized(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onResized():Signal<Void->Void> {
@@ -110,8 +92,6 @@ extern class Control extends godot.CanvasItem {
 
 	/**
 		`size_flags_changed` signal.
-		
-		Emitted when one of the size flags changes. See `sizeFlagsHorizontal` and `sizeFlagsVertical`.
 	**/
 	public var onSizeFlagsChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSizeFlagsChanged():Signal<Void->Void> {
@@ -236,7 +216,7 @@ extern class Control extends godot.CanvasItem {
 	public var rectClipContent:Bool;
 
 	/**		
-		By default, the node's pivot is its top-left corner. When you change its `godot.Control.rectScale`, it will scale around this pivot. Set this property to `godot.Control.rectSize` / 2 to center the pivot in the node's rectangle.
+		By default, the node's pivot is its top-left corner. When you change its `godot.Control.rectRotation` or `godot.Control.rectScale`, it will rotate or scale around this pivot. Set this property to `godot.Control.rectSize` / 2 to pivot around the Control's center.
 	**/
 	@:native("RectPivotOffset")
 	public var rectPivotOffset:godot.Vector2;
@@ -244,7 +224,7 @@ extern class Control extends godot.CanvasItem {
 	/**		
 		The node's scale, relative to its `godot.Control.rectSize`. Change this property to scale the node around its `godot.Control.rectPivotOffset`. The Control's `godot.Control.hintTooltip` will also scale according to this value.
 		
-		Note: This property is mainly intended to be used for animation purposes. Text inside the Control will look pixelated or blurry when the Control is scaled. To support multiple resolutions in your project, use an appropriate viewport stretch mode as described in the [https://docs.godotengine.org/en/3.4/tutorials/viewports/multiple_resolutions.html](documentation) instead of scaling Controls individually.
+		Note: This property is mainly intended to be used for animation purposes. Text inside the Control will look pixelated or blurry when the Control is scaled. To support multiple resolutions in your project, use an appropriate viewport stretch mode as described in the [https://docs.godotengine.org/en/3.4/tutorials/rendering/multiple_resolutions.html](documentation) instead of scaling Controls individually.
 		
 		Note: If the Control node is a child of a `godot.Container` node, the scale will be reset to `Vector2(1, 1)` when the scene is instanced. To set the Control's scale when it's instanced, wait for one frame using `yield(get_tree(), "idle_frame")` then set its `godot.Control.rectScale` property.
 	**/

--- a/godot/ConvexPolygonShape2D.hx
+++ b/godot/ConvexPolygonShape2D.hx
@@ -15,7 +15,7 @@ The main difference between a `godot.ConvexPolygonShape2D` and a `godot.ConcaveP
 @:autoBuild(godot.Godot.buildUserClass())
 extern class ConvexPolygonShape2D extends godot.Shape2D {
 	/**		
-		The polygon's list of vertices. Can be in either clockwise or counterclockwise order.
+		The polygon's list of vertices. Can be in either clockwise or counterclockwise order. Only set this property with convex hull points, use `godot.ConvexPolygonShape2D.setPointCloud` to generate a convex hull shape from concave shape points.
 	**/
 	@:native("Points")
 	public var points:cs.NativeArray<godot.Vector2>;

--- a/godot/Curve.hx
+++ b/godot/Curve.hx
@@ -14,8 +14,6 @@ A curve that can be saved and re-used for other objects. By default, it ranges b
 extern class Curve extends godot.Resource {
 	/**
 		`range_changed` signal.
-		
-		Emitted when `maxValue` or `minValue` is changed.
 	**/
 	public var onRangeChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRangeChanged():Signal<Void->Void> {

--- a/godot/Curve2D.hx
+++ b/godot/Curve2D.hx
@@ -34,7 +34,7 @@ extern class Curve2D extends godot.Resource {
 
 	#if doc_gen
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve2D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		
@@ -45,7 +45,7 @@ extern class Curve2D extends godot.Resource {
 	public function addPoint(position:godot.Vector2, ?in_:Null<godot.Vector2>, ?out:Null<godot.Vector2>, ?atPosition:Int):Void;
 	#else
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve2D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		
@@ -56,7 +56,7 @@ extern class Curve2D extends godot.Resource {
 	public overload function addPoint(position:godot.Vector2):Void;
 
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve2D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		
@@ -67,7 +67,7 @@ extern class Curve2D extends godot.Resource {
 	public overload function addPoint(position:godot.Vector2, in_:Nullable1<godot.Vector2>):Void;
 
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve2D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		
@@ -78,7 +78,7 @@ extern class Curve2D extends godot.Resource {
 	public overload function addPoint(position:godot.Vector2, in_:Nullable1<godot.Vector2>, out:Nullable1<godot.Vector2>):Void;
 
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve2D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		

--- a/godot/Curve3D.hx
+++ b/godot/Curve3D.hx
@@ -40,7 +40,7 @@ extern class Curve3D extends godot.Resource {
 
 	#if doc_gen
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve3D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		
@@ -51,7 +51,7 @@ extern class Curve3D extends godot.Resource {
 	public function addPoint(position:godot.Vector3, ?in_:Null<godot.Vector3>, ?out:Null<godot.Vector3>, ?atPosition:Int):Void;
 	#else
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve3D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		
@@ -62,7 +62,7 @@ extern class Curve3D extends godot.Resource {
 	public overload function addPoint(position:godot.Vector3):Void;
 
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve3D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		
@@ -73,7 +73,7 @@ extern class Curve3D extends godot.Resource {
 	public overload function addPoint(position:godot.Vector3, in_:Nullable1<godot.Vector3>):Void;
 
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve3D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		
@@ -84,7 +84,7 @@ extern class Curve3D extends godot.Resource {
 	public overload function addPoint(position:godot.Vector3, in_:Nullable1<godot.Vector3>, out:Nullable1<godot.Vector3>):Void;
 
 	/**		
-		Adds a point to a curve at `position`, with control points `in` and `out`.
+		Adds a point to a curve at `position` relative to the `godot.Curve3D`'s position, with control points `in` and `out`.
 		
 		If `at_position` is given, the point is inserted before the point number `at_position`, moving that point (and every point after) after the inserted point. If `at_position` is not given, or is an illegal value (`at_position &lt;0` or `at_position &gt;= [method get_point_count]`), the point will be appended at the end of the point list.
 		

--- a/godot/CurveTexture.hx
+++ b/godot/CurveTexture.hx
@@ -13,13 +13,13 @@ Renders a given `godot.Curve` provided to it. Simplifies the task of drawing cur
 @:autoBuild(godot.Godot.buildUserClass())
 extern class CurveTexture extends godot.Texture {
 	/**		
-		The `curve` rendered onto the texture.
+		The `godot.Curve` that is rendered onto the texture.
 	**/
 	@:native("Curve")
 	public var curve:godot.Curve;
 
 	/**		
-		The width of the texture.
+		The width of the texture (in pixels). Higher values make it possible to represent high-frequency data better (such as sudden direction changes), at the cost of increased generation time and memory usage.
 	**/
 	@:native("Width")
 	public var width:Int;

--- a/godot/EditorExportPlugin.hx
+++ b/godot/EditorExportPlugin.hx
@@ -5,7 +5,9 @@ package godot;
 import cs.system.*;
 
 /**
-Editor export plugins are automatically activated whenever the user exports the project. Their most common use is to determine what files are being included in the exported project. For each plugin, `godot.EditorExportPlugin._ExportBegin` is called at the beginning of the export process and then `godot.EditorExportPlugin._ExportFile` is called for each exported file.
+`godot.EditorExportPlugin`s are automatically invoked whenever the user exports the project. Their most common use is to determine what files are being included in the exported project. For each plugin, `godot.EditorExportPlugin._ExportBegin` is called at the beginning of the export process and then `godot.EditorExportPlugin._ExportFile` is called for each exported file.
+
+To use `godot.EditorExportPlugin`, register it using the `godot.EditorPlugin.addExportPlugin` method first.
 **/
 @:libType
 @:csNative

--- a/godot/EditorFileDialog.hx
+++ b/godot/EditorFileDialog.hx
@@ -11,8 +11,6 @@ import cs.system.*;
 extern class EditorFileDialog extends godot.ConfirmationDialog {
 	/**
 		`dir_selected` signal.
-		
-		Emitted when a directory is selected.
 	**/
 	public var onDirSelected(get, never):Signal<(dir:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onDirSelected():Signal<(dir:std.String)->Void> {
@@ -21,8 +19,6 @@ extern class EditorFileDialog extends godot.ConfirmationDialog {
 
 	/**
 		`file_selected` signal.
-		
-		Emitted when a file is selected.
 	**/
 	public var onFileSelected(get, never):Signal<(path:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFileSelected():Signal<(path:std.String)->Void> {
@@ -31,8 +27,6 @@ extern class EditorFileDialog extends godot.ConfirmationDialog {
 
 	/**
 		`files_selected` signal.
-		
-		Emitted when multiple files are selected.
 	**/
 	public var onFilesSelected(get, never):Signal<(paths:std.Array<std.String>)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFilesSelected():Signal<(paths:std.Array<std.String>)->Void> {

--- a/godot/EditorFileSystem.hx
+++ b/godot/EditorFileSystem.hx
@@ -16,8 +16,6 @@ Note: This class shouldn't be instantiated directly. Instead, access the singlet
 extern abstract class EditorFileSystem extends godot.Node {
 	/**
 		`filesystem_changed` signal.
-		
-		Emitted if the filesystem changed.
 	**/
 	public var onFilesystemChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFilesystemChanged():Signal<Void->Void> {
@@ -26,8 +24,6 @@ extern abstract class EditorFileSystem extends godot.Node {
 
 	/**
 		`resources_reimported` signal.
-		
-		Emitted if a resource is reimported.
 	**/
 	public var onResourcesReimported(get, never):Signal<(resources:std.Array<std.String>)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onResourcesReimported():Signal<(resources:std.Array<std.String>)->Void> {
@@ -36,8 +32,6 @@ extern abstract class EditorFileSystem extends godot.Node {
 
 	/**
 		`resources_reload` signal.
-		
-		Emitted if at least one resource is reloaded when the filesystem is scanned.
 	**/
 	public var onResourcesReload(get, never):Signal<(resources:std.Array<std.String>)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onResourcesReload():Signal<(resources:std.Array<std.String>)->Void> {
@@ -46,8 +40,6 @@ extern abstract class EditorFileSystem extends godot.Node {
 
 	/**
 		`sources_changed` signal.
-		
-		Emitted if the source of any imported file changed.
 	**/
 	public var onSourcesChanged(get, never):Signal<(exist:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSourcesChanged():Signal<(exist:Bool)->Void> {

--- a/godot/EditorImportPlugin.hx
+++ b/godot/EditorImportPlugin.hx
@@ -5,7 +5,7 @@ package godot;
 import cs.system.*;
 
 /**
-EditorImportPlugins provide a way to extend the editor's resource import functionality. Use them to import resources from custom files or to provide alternatives to the editor's existing importers. Register your `godot.EditorPlugin` with `godot.EditorPlugin.addImportPlugin`.
+`godot.EditorImportPlugin`s provide a way to extend the editor's resource import functionality. Use them to import resources from custom files or to provide alternatives to the editor's existing importers.
 
 EditorImportPlugins work by associating with specific file extensions and a resource type. See `godot.EditorImportPlugin.getRecognizedExtensions` and `godot.EditorImportPlugin.getResourceType`. They may optionally specify some import presets that affect the import process. EditorImportPlugins are responsible for creating the resources and saving them in the `.import` directory (see ).
 
@@ -52,6 +52,8 @@ var filename = save_path + "." + get_save_extension()
 return ResourceSaver.save(filename, mesh)
 
 ```
+
+To use `godot.EditorImportPlugin`, register it using the `godot.EditorPlugin.addImportPlugin` method first.
 **/
 @:libType
 @:csNative

--- a/godot/EditorInspector.hx
+++ b/godot/EditorInspector.hx
@@ -16,8 +16,6 @@ Note: This class shouldn't be instantiated directly. Instead, access the singlet
 extern class EditorInspector extends godot.ScrollContainer {
 	/**
 		`object_id_selected` signal.
-		
-		Emitted when the Edit button of an `Object` has been pressed in the inspector. This is mainly used in the remote scene tree inspector.
 	**/
 	public var onObjectIdSelected(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onObjectIdSelected():Signal<(id:Int)->Void> {
@@ -26,8 +24,6 @@ extern class EditorInspector extends godot.ScrollContainer {
 
 	/**
 		`property_edited` signal.
-		
-		Emitted when a property is edited in the inspector.
 	**/
 	public var onPropertyEdited(get, never):Signal<(property:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPropertyEdited():Signal<(property:std.String)->Void> {
@@ -36,8 +32,6 @@ extern class EditorInspector extends godot.ScrollContainer {
 
 	/**
 		`property_keyed` signal.
-		
-		Emitted when a property is keyed in the inspector. Properties can be keyed by clicking the "key" icon next to a property when the Animation panel is toggled.
 	**/
 	public var onPropertyKeyed(get, never):Signal<(property:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPropertyKeyed():Signal<(property:std.String)->Void> {
@@ -46,8 +40,6 @@ extern class EditorInspector extends godot.ScrollContainer {
 
 	/**
 		`property_selected` signal.
-		
-		Emitted when a property is selected in the inspector.
 	**/
 	public var onPropertySelected(get, never):Signal<(property:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPropertySelected():Signal<(property:std.String)->Void> {
@@ -56,9 +48,6 @@ extern class EditorInspector extends godot.ScrollContainer {
 
 	/**
 		`property_toggled` signal.
-		
-		Emitted when a boolean property is toggled in the inspector.
-		`b`Note:`/b` This signal is never emitted if the internal `autoclear` property enabled. Since this property is always enabled in the editor inspector, this signal is never emitted by the editor itself.
 	**/
 	public var onPropertyToggled(get, never):Signal<(property:std.String, checked:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPropertyToggled():Signal<(property:std.String, checked:Bool)->Void> {
@@ -67,8 +56,6 @@ extern class EditorInspector extends godot.ScrollContainer {
 
 	/**
 		`resource_selected` signal.
-		
-		Emitted when a resource is selected in the inspector.
 	**/
 	public var onResourceSelected(get, never):Signal<(res:godot.Object, prop:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onResourceSelected():Signal<(res:godot.Object, prop:std.String)->Void> {
@@ -77,8 +64,6 @@ extern class EditorInspector extends godot.ScrollContainer {
 
 	/**
 		`restart_requested` signal.
-		
-		Emitted when a property that requires a restart to be applied is edited in the inspector. This is only used in the Project Settings and Editor Settings.
 	**/
 	public var onRestartRequested(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRestartRequested():Signal<Void->Void> {

--- a/godot/EditorInspectorPlugin.hx
+++ b/godot/EditorInspectorPlugin.hx
@@ -5,9 +5,7 @@ package godot;
 import cs.system.*;
 
 /**
-These plugins allow adding custom property editors to `godot.EditorInspector`.
-
-Plugins are registered via `godot.EditorPlugin.addInspectorPlugin`.
+`godot.EditorInspectorPlugin` allows adding custom property editors to `godot.EditorInspector`.
 
 When an object is edited, the `godot.EditorInspectorPlugin.canHandle` function is called and must return `true` if the object type is supported.
 
@@ -18,6 +16,8 @@ Subsequently, the `godot.EditorInspectorPlugin.parseCategory` and `godot.EditorI
 Finally, `godot.EditorInspectorPlugin.parseEnd` will be called.
 
 On each of these calls, the "add" functions can be called.
+
+To use `godot.EditorInspectorPlugin`, register it using the `godot.EditorPlugin.addInspectorPlugin` method first.
 **/
 @:libType
 @:csNative

--- a/godot/EditorInterface.hx
+++ b/godot/EditorInterface.hx
@@ -83,7 +83,7 @@ extern abstract class EditorInterface extends godot.Node {
 	public function getEditorScale():Single;
 
 	/**		
-		Edits the given `godot.Resource`.
+		Edits the given `godot.Resource`. If the resource is a `godot.Script` you can also edit it with `godot.EditorInterface.editScript` to specify the line and column position.
 	**/
 	@:native("EditResource")
 	public function editResource(resource:godot.Resource):Void;
@@ -93,6 +93,38 @@ extern abstract class EditorInterface extends godot.Node {
 	**/
 	@:native("EditNode")
 	public function editNode(node:godot.Node):Void;
+
+	#if doc_gen
+	/**		
+		Edits the given `godot.Script`. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
+	**/
+	@:native("EditScript")
+	public function editScript(script:godot.Script, ?line:Int, ?column:Int, ?grabFocus:Bool):Void;
+	#else
+	/**		
+		Edits the given `godot.Script`. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
+	**/
+	@:native("EditScript")
+	public overload function editScript(script:godot.Script):Void;
+
+	/**		
+		Edits the given `godot.Script`. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
+	**/
+	@:native("EditScript")
+	public overload function editScript(script:godot.Script, line:Int):Void;
+
+	/**		
+		Edits the given `godot.Script`. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
+	**/
+	@:native("EditScript")
+	public overload function editScript(script:godot.Script, line:Int, column:Int):Void;
+
+	/**		
+		Edits the given `godot.Script`. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
+	**/
+	@:native("EditScript")
+	public overload function editScript(script:godot.Script, line:Int, column:Int, grabFocus:Bool):Void;
+	#end
 
 	/**		
 		Opens the scene at the given path.

--- a/godot/EditorPlugin.hx
+++ b/godot/EditorPlugin.hx
@@ -14,8 +14,6 @@ Plugins are used by the editor to extend functionality. The most common types of
 extern class EditorPlugin extends godot.Node {
 	/**
 		`main_screen_changed` signal.
-		
-		Emitted when user changes the workspace (`b`2D`/b`, `b`3D`/b`, `b`Script`/b`, `b`AssetLib`/b`). Also works with custom screens defined by plugins.
 	**/
 	public var onMainScreenChanged(get, never):Signal<(screenName:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMainScreenChanged():Signal<(screenName:std.String)->Void> {
@@ -32,8 +30,6 @@ extern class EditorPlugin extends godot.Node {
 
 	/**
 		`scene_changed` signal.
-		
-		Emitted when the scene is changed in the editor. The argument will return the root node of the scene that has just become active. If this scene is new and empty, the argument will be `null`.
 	**/
 	public var onSceneChanged(get, never):Signal<(sceneRoot:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSceneChanged():Signal<(sceneRoot:Node)->Void> {
@@ -42,8 +38,6 @@ extern class EditorPlugin extends godot.Node {
 
 	/**
 		`scene_closed` signal.
-		
-		Emitted when user closes a scene. The argument is file path to a closed scene.
 	**/
 	public var onSceneClosed(get, never):Signal<(filepath:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSceneClosed():Signal<(filepath:std.String)->Void> {

--- a/godot/EditorProperty.hx
+++ b/godot/EditorProperty.hx
@@ -14,8 +14,6 @@ This control allows property editing for one or multiple properties into `godot.
 extern class EditorProperty extends godot.Container {
 	/**
 		`multiple_properties_changed` signal.
-		
-		Emit it if you want multiple properties modified at the same time. Do not use if added via `editorInspectorPlugin.parseProperty`.
 	**/
 	public var onMultiplePropertiesChanged(get, never):Signal<(properties:std.Array<std.String>, value:godot.collections.Array)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMultiplePropertiesChanged():Signal<(properties:std.Array<std.String>, value:godot.collections.Array)->Void> {
@@ -24,8 +22,6 @@ extern class EditorProperty extends godot.Container {
 
 	/**
 		`object_id_selected` signal.
-		
-		Used by sub-inspectors. Emit it if what was selected was an Object ID.
 	**/
 	public var onObjectIdSelected(get, never):Signal<(property:std.String, id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onObjectIdSelected():Signal<(property:std.String, id:Int)->Void> {
@@ -34,8 +30,6 @@ extern class EditorProperty extends godot.Container {
 
 	/**
 		`property_changed` signal.
-		
-		Do not emit this manually, use the `emitChanged` method instead.
 	**/
 	public var onPropertyChanged(get, never):Signal<(property:std.String, value:Any)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPropertyChanged():Signal<(property:std.String, value:Any)->Void> {
@@ -44,8 +38,6 @@ extern class EditorProperty extends godot.Container {
 
 	/**
 		`property_checked` signal.
-		
-		Emitted when a property was checked. Used internally.
 	**/
 	public var onPropertyChecked(get, never):Signal<(property:std.String, bool:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPropertyChecked():Signal<(property:std.String, bool:std.String)->Void> {
@@ -54,8 +46,6 @@ extern class EditorProperty extends godot.Container {
 
 	/**
 		`property_keyed` signal.
-		
-		Emit it if you want to add this value as an animation key (check for keying being enabled first).
 	**/
 	public var onPropertyKeyed(get, never):Signal<(property:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPropertyKeyed():Signal<(property:std.String)->Void> {
@@ -64,8 +54,6 @@ extern class EditorProperty extends godot.Container {
 
 	/**
 		`property_keyed_with_value` signal.
-		
-		Emit it if you want to key a property with a single value.
 	**/
 	public var onPropertyKeyedWithValue(get, never):Signal<(property:std.String, value:Any)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPropertyKeyedWithValue():Signal<(property:std.String, value:Any)->Void> {
@@ -74,8 +62,6 @@ extern class EditorProperty extends godot.Container {
 
 	/**
 		`resource_selected` signal.
-		
-		If you want a sub-resource to be edited, emit this signal with the resource.
 	**/
 	public var onResourceSelected(get, never):Signal<(path:std.String, resource:Resource)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onResourceSelected():Signal<(path:std.String, resource:Resource)->Void> {
@@ -84,8 +70,6 @@ extern class EditorProperty extends godot.Container {
 
 	/**
 		`selected` signal.
-		
-		Emitted when selected. Used internally.
 	**/
 	public var onSelected(get, never):Signal<(path:std.String, focusableIdx:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSelected():Signal<(path:std.String, focusableIdx:Int)->Void> {

--- a/godot/EditorResourcePicker.hx
+++ b/godot/EditorResourcePicker.hx
@@ -16,8 +16,6 @@ Note: This `godot.Control` does not include any editor for the resource, as edit
 extern class EditorResourcePicker extends godot.HBoxContainer {
 	/**
 		`resource_changed` signal.
-		
-		Emitted when the value of the edited resource was changed.
 	**/
 	public var onResourceChanged(get, never):Signal<(resource:Resource)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onResourceChanged():Signal<(resource:Resource)->Void> {
@@ -26,8 +24,6 @@ extern class EditorResourcePicker extends godot.HBoxContainer {
 
 	/**
 		`resource_selected` signal.
-		
-		Emitted when the resource value was set and user clicked to edit it. When `edit` is `true`, the signal was caused by the context menu "Edit" option.
 	**/
 	public var onResourceSelected(get, never):Signal<(resource:Resource, edit:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onResourceSelected():Signal<(resource:Resource, edit:Bool)->Void> {
@@ -65,7 +61,7 @@ extern class EditorResourcePicker extends godot.HBoxContainer {
 		This virtual method can be implemented to handle context menu items not handled by default. See `godot.EditorResourcePicker.setCreateOptions`.
 	**/
 	@:native("HandleMenuSelected")
-	public function handleMenuSelected(id:Int):Void;
+	public function handleMenuSelected(id:Int):Bool;
 
 	/**		
 		This virtual method is called when updating the context menu of `godot.EditorResourcePicker`. Implement this method to override the "New ..." items with your own options. `menu_node` is a reference to the `godot.PopupMenu` node.

--- a/godot/EditorResourcePreview.hx
+++ b/godot/EditorResourcePreview.hx
@@ -16,8 +16,6 @@ Note: This class shouldn't be instantiated directly. Instead, access the singlet
 extern abstract class EditorResourcePreview extends godot.Node {
 	/**
 		`preview_invalidated` signal.
-		
-		Emitted if a preview was invalidated (changed). `path` corresponds to the path of the preview.
 	**/
 	public var onPreviewInvalidated(get, never):Signal<(path:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPreviewInvalidated():Signal<(path:std.String)->Void> {

--- a/godot/EditorSceneImporter.hx
+++ b/godot/EditorSceneImporter.hx
@@ -4,6 +4,11 @@ package godot;
 
 import cs.system.*;
 
+/**
+`godot.EditorSceneImporter` allows to define an importer script for a third-party 3D format.
+
+To use `godot.EditorSceneImporter`, register it using the `godot.EditorPlugin.addSceneImportPlugin` method first.
+**/
 @:libType
 @:csNative
 @:native("Godot.EditorSceneImporter")

--- a/godot/EditorSelection.hx
+++ b/godot/EditorSelection.hx
@@ -16,8 +16,6 @@ Note: This class shouldn't be instantiated directly. Instead, access the singlet
 extern class EditorSelection extends godot.Object {
 	/**
 		`selection_changed` signal.
-		
-		Emitted when the selection changes.
 	**/
 	public var onSelectionChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSelectionChanged():Signal<Void->Void> {

--- a/godot/EditorSettings.hx
+++ b/godot/EditorSettings.hx
@@ -32,8 +32,6 @@ Note: This class shouldn't be instantiated directly. Instead, access the singlet
 extern abstract class EditorSettings extends godot.Resource {
 	/**
 		`settings_changed` signal.
-		
-		Emitted after any editor setting has changed.
 	**/
 	public var onSettingsChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSettingsChanged():Signal<Void->Void> {

--- a/godot/EditorSpatialGizmo.hx
+++ b/godot/EditorSpatialGizmo.hx
@@ -96,31 +96,31 @@ extern class EditorSpatialGizmo extends godot.SpatialGizmo {
 		Adds a mesh to the gizmo with the specified `billboard` state, `skeleton` and `material`. If `billboard` is `true`, the mesh will rotate to always face the camera. Call this function during `godot.EditorSpatialGizmo.redraw`.
 	**/
 	@:native("AddMesh")
-	public function addMesh(mesh:godot.ArrayMesh, ?billboard:Bool, ?skeleton:godot.SkinReference, ?material:godot.Material):Void;
+	public function addMesh(mesh:godot.Mesh, ?billboard:Bool, ?skeleton:godot.SkinReference, ?material:godot.Material):Void;
 	#else
 	/**		
 		Adds a mesh to the gizmo with the specified `billboard` state, `skeleton` and `material`. If `billboard` is `true`, the mesh will rotate to always face the camera. Call this function during `godot.EditorSpatialGizmo.redraw`.
 	**/
 	@:native("AddMesh")
-	public overload function addMesh(mesh:godot.ArrayMesh):Void;
+	public overload function addMesh(mesh:godot.Mesh):Void;
 
 	/**		
 		Adds a mesh to the gizmo with the specified `billboard` state, `skeleton` and `material`. If `billboard` is `true`, the mesh will rotate to always face the camera. Call this function during `godot.EditorSpatialGizmo.redraw`.
 	**/
 	@:native("AddMesh")
-	public overload function addMesh(mesh:godot.ArrayMesh, billboard:Bool):Void;
+	public overload function addMesh(mesh:godot.Mesh, billboard:Bool):Void;
 
 	/**		
 		Adds a mesh to the gizmo with the specified `billboard` state, `skeleton` and `material`. If `billboard` is `true`, the mesh will rotate to always face the camera. Call this function during `godot.EditorSpatialGizmo.redraw`.
 	**/
 	@:native("AddMesh")
-	public overload function addMesh(mesh:godot.ArrayMesh, billboard:Bool, skeleton:godot.SkinReference):Void;
+	public overload function addMesh(mesh:godot.Mesh, billboard:Bool, skeleton:godot.SkinReference):Void;
 
 	/**		
 		Adds a mesh to the gizmo with the specified `billboard` state, `skeleton` and `material`. If `billboard` is `true`, the mesh will rotate to always face the camera. Call this function during `godot.EditorSpatialGizmo.redraw`.
 	**/
 	@:native("AddMesh")
-	public overload function addMesh(mesh:godot.ArrayMesh, billboard:Bool, skeleton:godot.SkinReference, material:godot.Material):Void;
+	public overload function addMesh(mesh:godot.Mesh, billboard:Bool, skeleton:godot.SkinReference, material:godot.Material):Void;
 	#end
 
 	/**		

--- a/godot/EditorSpatialGizmoPlugin.hx
+++ b/godot/EditorSpatialGizmoPlugin.hx
@@ -5,7 +5,9 @@ package godot;
 import cs.system.*;
 
 /**
-EditorSpatialGizmoPlugin allows you to define a new type of Gizmo. There are two main ways to do so: extending `godot.EditorSpatialGizmoPlugin` for the simpler gizmos, or creating a new `godot.EditorSpatialGizmo` type. See the tutorial in the documentation for more info.
+`godot.EditorSpatialGizmoPlugin` allows you to define a new type of Gizmo. There are two main ways to do so: extending `godot.EditorSpatialGizmoPlugin` for the simpler gizmos, or creating a new `godot.EditorSpatialGizmo` type. See the tutorial in the documentation for more info.
+
+To use `godot.EditorSpatialGizmoPlugin`, register it using the `godot.EditorPlugin.addSpatialGizmoPlugin` method first.
 **/
 @:libType
 @:csNative

--- a/godot/Engine.hx
+++ b/godot/Engine.hx
@@ -36,7 +36,9 @@ extern class Engine {
 	public static var TARGET_FPS:Int;
 
 	/**		
-		The number of fixed iterations per second. This controls how often physics simulation and `godot.Node._PhysicsProcess` methods are run. This value should generally always be set to `60` or above, as Godot doesn't interpolate the physics step. As a result, values lower than `60` will look stuttery. This value can be increased to make input more reactive or work around tunneling issues, but keep in mind doing so will increase CPU usage.
+		The number of fixed iterations per second. This controls how often physics simulation and `godot.Node._PhysicsProcess` methods are run. This value should generally always be set to `60` or above, as Godot doesn't interpolate the physics step. As a result, values lower than `60` will look stuttery. This value can be increased to make input more reactive or work around collision tunneling issues, but keep in mind doing so will increase CPU usage. See also `godot.Engine.targetFps` and .
+		
+		Note: Only 8 physics ticks may be simulated per rendered frame at most. If more than 8 physics ticks have to be simulated per rendered frame to keep up with rendering, the game will appear to slow down (even if `delta` is used consistently in physics calculations). Therefore, it is recommended not to increase `godot.Engine.iterationsPerSecond` above 240. Otherwise, the game will slow down when the rendering framerate goes below 30 FPS.
 	**/
 	@:native("IterationsPerSecond")
 	public static var ITERATIONS_PER_SECOND:Int;
@@ -44,7 +46,7 @@ extern class Engine {
 	/**		
 		If `false`, stops printing error and warning messages to the console and editor Output log. This can be used to hide error and warning messages during unit test suite runs. This property is equivalent to the  project setting.
 		
-		Warning: If you set this to `false` anywhere in the project, important error messages may be hidden even if they are emitted from other scripts. If this is set to `false` in a `@tool` script, this will also impact the editor itself. Do not report bugs before ensuring error messages are enabled (as they are by default).
+		Warning: If you set this to `false` anywhere in the project, important error messages may be hidden even if they are emitted from other scripts. If this is set to `false` in a `tool` script, this will also impact the editor itself. Do not report bugs before ensuring error messages are enabled (as they are by default).
 		
 		Note: This property does not impact the editor's Errors tab when running a project from the editor.
 	**/

--- a/godot/Environment.hx
+++ b/godot/Environment.hx
@@ -15,7 +15,15 @@ Resource for environment nodes (like `godot.WorldEnvironment`) that define multi
 
 - Adjustments
 
-These effects will only apply when the `godot.Viewport`'s intended usage is "3D" or "3D Without Effects". This can be configured for the root Viewport with , or for specific Viewports via the `godot.Viewport.usage` property.
+If the target `godot.Viewport` is set to "2D Without Sampling", all post-processing effects will be unavailable. With "3D Without Effects", the following options will be unavailable:
+
+- Ssao
+
+- Ss Reflections
+
+This can be configured for the root Viewport with , or for specific Viewports via the `godot.Viewport.usage` property.
+
+Note that  has a mobile platform override to use "3D Without Effects" by default. It improves the performance on mobile devices, but at the same time affects the screen display on mobile devices.
 **/
 @:libType
 @:csNative
@@ -152,6 +160,10 @@ extern class Environment extends godot.Resource {
 
 	/**		
 		If `true`, the glow effect is enabled.
+		
+		Note: Only effective if  is 3D (not 3D Without Effects). On mobile,  defaults to 3D Without Effects by default, so its `.mobile` override needs to be changed to 3D.
+		
+		Note: When using GLES3 on mobile, HDR rendering is disabled by default for performance reasons. This means glow will only be visible if `godot.Environment.glowHdrThreshold` is decreased below `1.0` or if `godot.Environment.glowBloom` is increased above `0.0`. Also consider increasing `godot.Environment.glowIntensity` to `1.5`. If you want glow to behave on mobile like it does on desktop (at a performance cost), enable 's `.mobile` override.
 	**/
 	@:native("GlowEnabled")
 	public var glowEnabled:Bool;
@@ -457,7 +469,9 @@ extern class Environment extends godot.Resource {
 	public var fogEnabled:Bool;
 
 	/**		
-		Defines the amount of light that the sky brings on the scene. A value of 0 means that the sky's light emission has no effect on the scene illumination, thus all ambient illumination is provided by the ambient light. On the contrary, a value of 1 means that all the light that affects the scene is provided by the sky, thus the ambient light parameter has no effect on the scene.
+		Defines the amount of light that the sky brings on the scene. A value of `0.0` means that the sky's light emission has no effect on the scene illumination, thus all ambient illumination is provided by the ambient light. On the contrary, a value of `1.0` means that all the light that affects the scene is provided by the sky, thus the ambient light parameter has no effect on the scene.
+		
+		Note: `godot.Environment.ambientLightSkyContribution` is internally clamped between `0.0` and `1.0` (inclusive).
 	**/
 	@:native("AmbientLightSkyContribution")
 	public var ambientLightSkyContribution:Single;

--- a/godot/Environment_BGMode.hx
+++ b/godot/Environment_BGMode.hx
@@ -31,7 +31,9 @@ extern enum Environment_BGMode {
 	Canvas;
 
 	/**		
-		Keeps on screen every pixel drawn in the background. This is the fastest background mode, but it can only be safely used in fully-interior scenes (no visible sky or sky reflections). If enabled in a scene where the background is visible, "ghost trail" artifacts will be visible when moving the camera.
+		Keeps on screen every pixel drawn in the background. Only select this mode if you really need to keep the old data. On modern GPUs it will generally not be faster than clearing the background, and can be significantly slower, particularly on mobile.
+		
+		It can only be safely used in fully-interior scenes (no visible sky or sky reflections). If enabled in a scene where the background is visible, "ghost trail" artifacts will be visible when moving the camera.
 	**/
 	Keep;
 

--- a/godot/Environment_ToneMapper.hx
+++ b/godot/Environment_ToneMapper.hx
@@ -6,27 +6,29 @@ package godot;
 @:csNative
 extern enum Environment_ToneMapper {
 	/**		
-		Linear tonemapper operator. Reads the linear data and passes it on unmodified.
+		Linear tonemapper operator. Reads the linear data and passes it on unmodified. This can cause bright lighting to look blown out, with noticeable clipping in the output colors.
 	**/
 	Linear;
 
 	/**		
-		Reinhardt tonemapper operator. Performs a variation on rendered pixels' colors by this formula: `color = color / (1 + color)`.
+		Reinhardt tonemapper operator. Performs a variation on rendered pixels' colors by this formula: `color = color / (1 + color)`. This avoids clipping bright highlights, but the resulting image can look a bit dull.
 	**/
 	Reinhardt;
 
 	/**		
-		Filmic tonemapper operator.
+		Filmic tonemapper operator. This avoids clipping bright highlights, with a resulting image that usually looks more vivid than `godot.Environment_ToneMapper.reinhardt`.
 	**/
 	Filmic;
 
 	/**		
-		Academy Color Encoding System tonemapper operator. Performs an aproximation of the ACES tonemapping curve.
+		Use the legacy Godot version of the Academy Color Encoding System tonemapper. Unlike `godot.Environment_ToneMapper.acesFitted`, this version of ACES does not handle bright lighting in a physically accurate way. ACES typically has a more contrasted output compared to `godot.Environment_ToneMapper.reinhardt` and `godot.Environment_ToneMapper.filmic`.
+		
+		Note: This tonemapping operator will be removed in Godot 4.0 in favor of the more accurate `godot.Environment_ToneMapper.acesFitted`.
 	**/
 	Aces;
 
 	/**		
-		High quality Academy Color Encoding System tonemapper operator that matches the industry standard. Performs a more physically accurate curve fit which better simulates how light works in the real world. The color of lights and emissive materials will become lighter as the emissive energy increases, and will eventually become white if the light is bright enough to saturate the camera sensor.
+		Use the Academy Color Encoding System tonemapper. ACES is slightly more expensive than other options, but it handles bright lighting in a more realistic fashion by desaturating it as it becomes brighter. ACES typically has a more contrasted output compared to `godot.Environment_ToneMapper.reinhardt` and `godot.Environment_ToneMapper.filmic`.
 	**/
 	AcesFitted;
 }

--- a/godot/File.hx
+++ b/godot/File.hx
@@ -484,6 +484,8 @@ extern class File extends godot.Reference {
 
 	/**		
 		Appends `string` to the file without a line return, encoding the text as UTF-8.
+		
+		Note: This method is intended to be used to write text files. The string is stored as a UTF-8 encoded buffer without string length or terminating zero, which means that it can't be loaded back easily. If you want to store a retrievable string in a binary file, consider using `godot.File.storePascalString` instead. For retrieving strings from a text file, you can use `get_buffer(length).get_string_from_utf8()` (if you know the length) or `godot.File.getAsText`.
 	**/
 	@:native("StoreString")
 	public function storeString(string:std.String):Void;

--- a/godot/FileDialog.hx
+++ b/godot/FileDialog.hx
@@ -14,8 +14,6 @@ FileDialog is a preset dialog used to choose files and directories in the filesy
 extern class FileDialog extends godot.ConfirmationDialog {
 	/**
 		`dir_selected` signal.
-		
-		Emitted when the user selects a directory.
 	**/
 	public var onDirSelected(get, never):Signal<(dir:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onDirSelected():Signal<(dir:std.String)->Void> {
@@ -24,8 +22,6 @@ extern class FileDialog extends godot.ConfirmationDialog {
 
 	/**
 		`file_selected` signal.
-		
-		Emitted when the user selects a file by double-clicking it or pressing the `b`OK`/b` button.
 	**/
 	public var onFileSelected(get, never):Signal<(path:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFileSelected():Signal<(path:std.String)->Void> {
@@ -34,8 +30,6 @@ extern class FileDialog extends godot.ConfirmationDialog {
 
 	/**
 		`files_selected` signal.
-		
-		Emitted when the user selects multiple files.
 	**/
 	public var onFilesSelected(get, never):Signal<(paths:std.Array<std.String>)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFilesSelected():Signal<(paths:std.Array<std.String>)->Void> {
@@ -67,7 +61,7 @@ extern class FileDialog extends godot.ConfirmationDialog {
 	public var showHiddenFiles:Bool;
 
 	/**		
-		The available file type filters. For example, this shows only `.png` and `.gd` files: `set_filters(PoolStringArray(["*.png ; PNG Images","*.gd ; GDScript Files"]))`.
+		The available file type filters. For example, this shows only `.png` and `.gd` files: `set_filters(PoolStringArray(["*.png ; PNG Images","*.gd ; GDScript Files"]))`. Multiple file types can also be specified in a single filter. `"*.png, *.jpg, *.jpeg ; Supported Images"` will show both PNG and JPEG files when selected.
 	**/
 	@:native("Filters")
 	public var filters:cs.NativeArray<std.String>;
@@ -102,7 +96,11 @@ extern class FileDialog extends godot.ConfirmationDialog {
 	public function clearFilters():Void;
 
 	/**		
-		Adds `filter` as a custom filter; `filter` should be of the form `"filename.extension ; Description"`. For example, `"*.png ; PNG Images"`.
+		Adds `filter` to the list of filters, which restricts what files can be picked.
+		
+		A `filter` should be of the form `"filename.extension ; Description"`, where filename and extension can be `*` to match any string. Filters starting with `.` (i.e. empty filenames) are not allowed.
+		
+		Example filters: `"*.png ; PNG Images"`, `"project.godot ; Godot Project"`.
 	**/
 	@:native("AddFilter")
 	public function addFilter(filter:std.String):Void;

--- a/godot/GIProbe.hx
+++ b/godot/GIProbe.hx
@@ -9,7 +9,11 @@ import cs.system.*;
 
 Having `godot.GIProbe`s in a scene can be expensive, the quality of the probe can be turned down in exchange for better performance in the `godot.ProjectSettings` using .
 
-Note: Meshes should have sufficiently thick walls to avoid light leaks (avoid one-sided walls). For interior levels, enclose your level geometry in a sufficiently large box and bridge the loops to close the mesh.
+Procedural generation: `godot.GIProbe` can be baked in an exported project, which makes it suitable for procedurally generated or user-built levels as long as all the geometry is generated in advance.
+
+Performance: `godot.GIProbe` is relatively demanding on the GPU and is not suited to low-end hardware such as integrated graphics (consider `godot.BakedLightmap` instead). To provide a fallback for low-end hardware, consider adding an option to disable `godot.GIProbe` in your project's options menus. A `godot.GIProbe` node can be disabled by hiding it.
+
+Note: Meshes should have sufficiently thick walls to avoid light leaks (avoid one-sided walls). For interior levels, enclose your level geometry in a sufficiently large box and bridge the loops to close the mesh. To further prevent light leaks, you can also strategically place temporary `godot.MeshInstance` nodes with `godot.GeometryInstance.useInBakedLight` enabled. These temporary nodes can then be hidden after baking the `godot.GIProbe` node.
 
 Note: Due to a renderer limitation, emissive `godot.ShaderMaterial`s cannot emit light when used in a `godot.GIProbe`. Only emissive `godot.SpatialMaterial`s can emit light in a `godot.GIProbe`.
 **/
@@ -146,24 +150,40 @@ extern class GIProbe extends godot.VisualInstance {
 	#if doc_gen
 	/**		
 		Bakes the effect from all `godot.GeometryInstance`s marked with `godot.GeometryInstance.useInBakedLight` and `godot.Light`s marked with either `godot.Light_BakeMode.indirect` or `godot.Light_BakeMode.all`. If `create_visual_debug` is `true`, after baking the light, this will generate a `godot.MultiMesh` that has a cube representing each solid cell with each cube colored to the cell's albedo color. This can be used to visualize the `godot.GIProbe`'s data and debug any issues that may be occurring.
+		
+		Note: `godot.GIProbe.bake` works from the editor and in exported projects. This makes it suitable for procedurally generated or user-built levels. Baking a `godot.GIProbe` generally takes from 5 to 20 seconds in most scenes. Reducing `godot.GIProbe.subdiv` can speed up baking.
+		
+		Note: `godot.GeometryInstance`s and `godot.Light`s must be fully ready before `godot.GIProbe.bake` is called. If you are procedurally creating those and some meshes or lights are missing from your baked `godot.GIProbe`, use `call_deferred("bake")` instead of calling `godot.GIProbe.bake` directly.
 	**/
 	@:native("Bake")
 	public function bake(?fromNode:godot.Node, ?createVisualDebug:Bool):Void;
 	#else
 	/**		
 		Bakes the effect from all `godot.GeometryInstance`s marked with `godot.GeometryInstance.useInBakedLight` and `godot.Light`s marked with either `godot.Light_BakeMode.indirect` or `godot.Light_BakeMode.all`. If `create_visual_debug` is `true`, after baking the light, this will generate a `godot.MultiMesh` that has a cube representing each solid cell with each cube colored to the cell's albedo color. This can be used to visualize the `godot.GIProbe`'s data and debug any issues that may be occurring.
+		
+		Note: `godot.GIProbe.bake` works from the editor and in exported projects. This makes it suitable for procedurally generated or user-built levels. Baking a `godot.GIProbe` generally takes from 5 to 20 seconds in most scenes. Reducing `godot.GIProbe.subdiv` can speed up baking.
+		
+		Note: `godot.GeometryInstance`s and `godot.Light`s must be fully ready before `godot.GIProbe.bake` is called. If you are procedurally creating those and some meshes or lights are missing from your baked `godot.GIProbe`, use `call_deferred("bake")` instead of calling `godot.GIProbe.bake` directly.
 	**/
 	@:native("Bake")
 	public overload function bake():Void;
 
 	/**		
 		Bakes the effect from all `godot.GeometryInstance`s marked with `godot.GeometryInstance.useInBakedLight` and `godot.Light`s marked with either `godot.Light_BakeMode.indirect` or `godot.Light_BakeMode.all`. If `create_visual_debug` is `true`, after baking the light, this will generate a `godot.MultiMesh` that has a cube representing each solid cell with each cube colored to the cell's albedo color. This can be used to visualize the `godot.GIProbe`'s data and debug any issues that may be occurring.
+		
+		Note: `godot.GIProbe.bake` works from the editor and in exported projects. This makes it suitable for procedurally generated or user-built levels. Baking a `godot.GIProbe` generally takes from 5 to 20 seconds in most scenes. Reducing `godot.GIProbe.subdiv` can speed up baking.
+		
+		Note: `godot.GeometryInstance`s and `godot.Light`s must be fully ready before `godot.GIProbe.bake` is called. If you are procedurally creating those and some meshes or lights are missing from your baked `godot.GIProbe`, use `call_deferred("bake")` instead of calling `godot.GIProbe.bake` directly.
 	**/
 	@:native("Bake")
 	public overload function bake(fromNode:godot.Node):Void;
 
 	/**		
 		Bakes the effect from all `godot.GeometryInstance`s marked with `godot.GeometryInstance.useInBakedLight` and `godot.Light`s marked with either `godot.Light_BakeMode.indirect` or `godot.Light_BakeMode.all`. If `create_visual_debug` is `true`, after baking the light, this will generate a `godot.MultiMesh` that has a cube representing each solid cell with each cube colored to the cell's albedo color. This can be used to visualize the `godot.GIProbe`'s data and debug any issues that may be occurring.
+		
+		Note: `godot.GIProbe.bake` works from the editor and in exported projects. This makes it suitable for procedurally generated or user-built levels. Baking a `godot.GIProbe` generally takes from 5 to 20 seconds in most scenes. Reducing `godot.GIProbe.subdiv` can speed up baking.
+		
+		Note: `godot.GeometryInstance`s and `godot.Light`s must be fully ready before `godot.GIProbe.bake` is called. If you are procedurally creating those and some meshes or lights are missing from your baked `godot.GIProbe`, use `call_deferred("bake")` instead of calling `godot.GIProbe.bake` directly.
 	**/
 	@:native("Bake")
 	public overload function bake(fromNode:godot.Node, createVisualDebug:Bool):Void;

--- a/godot/GIProbe_SubdivEnum.hx
+++ b/godot/GIProbe_SubdivEnum.hx
@@ -21,7 +21,7 @@ extern enum GIProbe_SubdivEnum {
 	Subdiv256;
 
 	/**		
-		Use 512 subdivisions. This is the highest quality setting, but the slowest. On lower-end hardware this could cause the GPU to stall.
+		Use 512 subdivisions. This is the highest quality setting, but the slowest. On lower-end hardware, this could cause the GPU to stall.
 	**/
 	Subdiv512;
 

--- a/godot/GLTFLight.hx
+++ b/godot/GLTFLight.hx
@@ -4,6 +4,9 @@ package godot;
 
 import cs.system.*;
 
+/**
+Note: This class is only compiled in editor builds. Run-time glTF loading and saving is not available in exported projects. References to `godot.GLTFLight` within a script will cause an error in an exported project.
+**/
 @:libType
 @:csNative
 @:native("Godot.GLTFLight")

--- a/godot/Geometry.hx
+++ b/godot/Geometry.hx
@@ -74,13 +74,13 @@ extern class Geometry {
 	public static function segmentIntersectsCircle(segmentFrom:godot.Vector2, segmentTo:godot.Vector2, circlePosition:godot.Vector2, circleRadius:Single):Single;
 
 	/**		
-		Checks if the two segments (`from_a`, `to_a`) and (`from_b`, `to_b`) intersect. If yes, return the point of intersection as `godot.Vector2`. If no intersection takes place, returns an empty `Variant`.
+		Checks if the two segments (`from_a`, `to_a`) and (`from_b`, `to_b`) intersect. If yes, return the point of intersection as `godot.Vector2`. If no intersection takes place, returns `null`.
 	**/
 	@:native("SegmentIntersectsSegment2d")
 	public static function segmentIntersectsSegment2d(fromA:godot.Vector2, toA:godot.Vector2, fromB:godot.Vector2, toB:godot.Vector2):Dynamic;
 
 	/**		
-		Checks if the two lines (`from_a`, `dir_a`) and (`from_b`, `dir_b`) intersect. If yes, return the point of intersection as `godot.Vector2`. If no intersection takes place, returns an empty `Variant`.
+		Checks if the two lines (`from_a`, `dir_a`) and (`from_b`, `dir_b`) intersect. If yes, return the point of intersection as `godot.Vector2`. If no intersection takes place, returns `null`.
 		
 		Note: The lines are specified using direction vectors, not end points.
 	**/
@@ -183,7 +183,7 @@ extern class Geometry {
 	public static function isPointInPolygon(point:godot.Vector2, polygon:HaxeArray<godot.Vector2>):Bool;
 
 	/**		
-		Triangulates the polygon specified by the points in `polygon`. Returns a `Int` where each triangle consists of three consecutive point indices into `polygon` (i.e. the returned array will have `n * 3` elements, with `n` being the number of found triangles). If the triangulation did not succeed, an empty `Int` is returned.
+		Triangulates the polygon specified by the points in `polygon`. Returns a `Int` where each triangle consists of three consecutive point indices into `polygon` (i.e. the returned array will have `n * 3` elements, with `n` being the number of found triangles). Output triangles will always be counter clockwise, and the contour will be flipped if it's clockwise. If the triangulation did not succeed, an empty `Int` is returned.
 	**/
 	public static extern inline function triangulatePolygon(polygon:HaxeArray<godot.Vector2>):std.Array<Int> {
 		return cs.Lib.array(cs.Syntax.code("TriangulatePolygon({0})", polygon));

--- a/godot/GradientTexture.hx
+++ b/godot/GradientTexture.hx
@@ -5,7 +5,7 @@ package godot;
 import cs.system.*;
 
 /**
-GradientTexture uses a `godot.Gradient` to fill the texture data. The gradient will be filled from left to right using colors obtained from the gradient. This means the texture does not necessarily represent an exact copy of the gradient, but instead an interpolation of samples obtained from the gradient at fixed steps (see `godot.GradientTexture.width`).
+GradientTexture uses a `godot.Gradient` to fill the texture data. The gradient will be filled from left to right using colors obtained from the gradient. This means the texture does not necessarily represent an exact copy of the gradient, but instead an interpolation of samples obtained from the gradient at fixed steps (see `godot.GradientTexture.width`). See also `godot.CurveTexture`.
 **/
 @:libType
 @:csNative

--- a/godot/GraphEdit.hx
+++ b/godot/GraphEdit.hx
@@ -16,8 +16,6 @@ It is greatly advised to enable low-processor usage mode (see `godot.OS.lowProce
 extern class GraphEdit extends godot.Control {
 	/**
 		`_begin_node_move` signal.
-		
-		Emitted at the beginning of a GraphNode movement.
 	**/
 	public var onBeginNodeMove(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBeginNodeMove():Signal<Void->Void> {
@@ -26,8 +24,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`_end_node_move` signal.
-		
-		Emitted at the end of a GraphNode movement.
 	**/
 	public var onEndNodeMove(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onEndNodeMove():Signal<Void->Void> {
@@ -36,8 +32,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`connection_from_empty` signal.
-		
-		Emitted when user dragging connection from input port into empty space of the graph.
 	**/
 	public var onConnectionFromEmpty(get, never):Signal<(to:std.String, toSlot:Int, releasePosition:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectionFromEmpty():Signal<(to:std.String, toSlot:Int, releasePosition:Vector2)->Void> {
@@ -46,8 +40,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`connection_request` signal.
-		
-		Emitted to the GraphEdit when the connection between the `from_slot` slot of the `from` GraphNode and the `to_slot` slot of the `to` GraphNode is attempted to be created.
 	**/
 	public var onConnectionRequest(get, never):Signal<(from:std.String, fromSlot:Int, to:std.String, toSlot:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectionRequest():Signal<(from:std.String, fromSlot:Int, to:std.String, toSlot:Int)->Void> {
@@ -56,8 +48,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`connection_to_empty` signal.
-		
-		Emitted when user dragging connection from output port into empty space of the graph.
 	**/
 	public var onConnectionToEmpty(get, never):Signal<(from:std.String, fromSlot:Int, releasePosition:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectionToEmpty():Signal<(from:std.String, fromSlot:Int, releasePosition:Vector2)->Void> {
@@ -66,8 +56,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`copy_nodes_request` signal.
-		
-		Emitted when the user presses `Ctrl + C`.
 	**/
 	public var onCopyNodesRequest(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCopyNodesRequest():Signal<Void->Void> {
@@ -76,8 +64,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`delete_nodes_request` signal.
-		
-		Emitted when a GraphNode is attempted to be removed from the GraphEdit.
 	**/
 	public var onDeleteNodesRequest(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onDeleteNodesRequest():Signal<Void->Void> {
@@ -86,8 +72,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`disconnection_request` signal.
-		
-		Emitted to the GraphEdit when the connection between `from_slot` slot of `from` GraphNode and `to_slot` slot of `to` GraphNode is attempted to be removed.
 	**/
 	public var onDisconnectionRequest(get, never):Signal<(from:std.String, fromSlot:Int, to:std.String, toSlot:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onDisconnectionRequest():Signal<(from:std.String, fromSlot:Int, to:std.String, toSlot:Int)->Void> {
@@ -96,8 +80,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`duplicate_nodes_request` signal.
-		
-		Emitted when a GraphNode is attempted to be duplicated in the GraphEdit.
 	**/
 	public var onDuplicateNodesRequest(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onDuplicateNodesRequest():Signal<Void->Void> {
@@ -106,8 +88,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`node_selected` signal.
-		
-		Emitted when a GraphNode is selected.
 	**/
 	public var onNodeSelected(get, never):Signal<(node:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNodeSelected():Signal<(node:Node)->Void> {
@@ -124,8 +104,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`paste_nodes_request` signal.
-		
-		Emitted when the user presses `Ctrl + V`.
 	**/
 	public var onPasteNodesRequest(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPasteNodesRequest():Signal<Void->Void> {
@@ -134,8 +112,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`popup_request` signal.
-		
-		Emitted when a popup is requested. Happens on right-clicking in the GraphEdit. `position` is the position of the mouse pointer when the signal is sent.
 	**/
 	public var onPopupRequest(get, never):Signal<(position:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPopupRequest():Signal<(position:Vector2)->Void> {
@@ -144,8 +120,6 @@ extern class GraphEdit extends godot.Control {
 
 	/**
 		`scroll_offset_changed` signal.
-		
-		Emitted when the scroll offset is changed by the user. It will not be emitted when changed in code.
 	**/
 	public var onScrollOffsetChanged(get, never):Signal<(ofs:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScrollOffsetChanged():Signal<(ofs:Vector2)->Void> {

--- a/godot/GraphNode.hx
+++ b/godot/GraphNode.hx
@@ -18,8 +18,6 @@ In the Inspector you can enable (show) or disable (hide) slots. By default, all 
 extern class GraphNode extends godot.Container {
 	/**
 		`close_request` signal.
-		
-		Emitted when the GraphNode is requested to be closed. Happens on clicking the close button (see `showClose`).
 	**/
 	public var onCloseRequest(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCloseRequest():Signal<Void->Void> {
@@ -28,8 +26,6 @@ extern class GraphNode extends godot.Container {
 
 	/**
 		`dragged` signal.
-		
-		Emitted when the GraphNode is dragged.
 	**/
 	public var onDragged(get, never):Signal<(from:Vector2, to:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onDragged():Signal<(from:Vector2, to:Vector2)->Void> {
@@ -38,8 +34,6 @@ extern class GraphNode extends godot.Container {
 
 	/**
 		`offset_changed` signal.
-		
-		Emitted when the GraphNode is moved.
 	**/
 	public var onOffsetChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onOffsetChanged():Signal<Void->Void> {
@@ -48,8 +42,6 @@ extern class GraphNode extends godot.Container {
 
 	/**
 		`raise_request` signal.
-		
-		Emitted when the GraphNode is requested to be displayed over other ones. Happens on focusing (clicking into) the GraphNode.
 	**/
 	public var onRaiseRequest(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRaiseRequest():Signal<Void->Void> {
@@ -58,8 +50,6 @@ extern class GraphNode extends godot.Container {
 
 	/**
 		`resize_request` signal.
-		
-		Emitted when the GraphNode is requested to be resized. Happens on dragging the resizer handle (see `resizable`).
 	**/
 	public var onResizeRequest(get, never):Signal<(newMinsize:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onResizeRequest():Signal<(newMinsize:Vector2)->Void> {
@@ -68,8 +58,6 @@ extern class GraphNode extends godot.Container {
 
 	/**
 		`slot_updated` signal.
-		
-		Emitted when any GraphNode's slot is updated.
 	**/
 	public var onSlotUpdated(get, never):Signal<(idx:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSlotUpdated():Signal<(idx:Int)->Void> {

--- a/godot/HMACContext.hx
+++ b/godot/HMACContext.hx
@@ -17,7 +17,7 @@ var key = "supersecret".to_utf8()
 var err = ctx.start(HashingContext.HASH_SHA256, key)
 assert(err == OK)
 var msg1 = "this is ".to_utf8()
-var msg2 = "vewy vewy secret".to_utf8()
+var msg2 = "super duper secret".to_utf8()
 err = ctx.update(msg1)
 assert(err == OK)
 err = ctx.update(msg2)
@@ -44,7 +44,7 @@ PoolByteArray key = String("supersecret").to_utf8();
 Error err = ctx.Start(HashingContext.HASH_SHA256, key);
 GD.Assert(err == OK);
 PoolByteArray msg1 = String("this is ").to_utf8();
-PoolByteArray msg2 = String("vewy vew secret").to_utf8();
+PoolByteArray msg2 = String("super duper secret").to_utf8();
 err = ctx.Update(msg1);
 GD.Assert(err == OK);
 err = ctx.Update(msg2);

--- a/godot/HTTPRequest.hx
+++ b/godot/HTTPRequest.hx
@@ -82,8 +82,6 @@ texture_rect.texture = texture
 extern class HTTPRequest extends godot.Node {
 	/**
 		`request_completed` signal.
-		
-		Emitted when a request is completed.
 	**/
 	public var onRequestCompleted(get, never):Signal<(result:Int, responseCode:Int, headers:std.Array<std.String>, body:std.Array<cs.types.UInt8>)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRequestCompleted():Signal<(result:Int, responseCode:Int, headers:std.Array<std.String>, body:std.Array<cs.types.UInt8>)->Void> {

--- a/godot/HeightMapShape.hx
+++ b/godot/HeightMapShape.hx
@@ -19,13 +19,13 @@ extern class HeightMapShape extends godot.Shape {
 	public var mapData:cs.NativeArray<Single>;
 
 	/**		
-		Depth of the height map data. Changing this will resize the `godot.HeightMapShape.mapData`.
+		Number of vertices in the depth of the height map. Changing this will resize the `godot.HeightMapShape.mapData`.
 	**/
 	@:native("MapDepth")
 	public var mapDepth:Int;
 
 	/**		
-		Width of the height map data. Changing this will resize the `godot.HeightMapShape.mapData`.
+		Number of vertices in the width of the height map. Changing this will resize the `godot.HeightMapShape.mapData`.
 	**/
 	@:native("MapWidth")
 	public var mapWidth:Int;

--- a/godot/Image.hx
+++ b/godot/Image.hx
@@ -213,7 +213,7 @@ extern class Image extends godot.Resource {
 	public function isEmpty():Bool;
 
 	/**		
-		Loads an image from file `path`. See [https://docs.godotengine.org/en/3.4/getting_started/workflow/assets/importing_images.html#supported-image-formats](Supported image formats) for a list of supported image formats and limitations.
+		Loads an image from file `path`. See [https://docs.godotengine.org/en/3.4/tutorials/assets_pipeline/importing_images.html#supported-image-formats](Supported image formats) for a list of supported image formats and limitations.
 		
 		Warning: This method should only be used in the editor or in cases when you need to load external images at run-time, such as images located at the `user://` directory, and may not work in exported projects.
 		

--- a/godot/Image_CompressSource.hx
+++ b/godot/Image_CompressSource.hx
@@ -19,4 +19,9 @@ extern enum Image_CompressSource {
 		Source texture (before compression) is a normal texture (e.g. it can be compressed into two channels).
 	**/
 	Normal;
+
+	/**		
+		Source texture (before compression) is a `godot.TextureLayered`.
+	**/
+	Layered;
 }

--- a/godot/Input.hx
+++ b/godot/Input.hx
@@ -14,8 +14,6 @@ A singleton that deals with inputs. This includes key presses, mouse buttons and
 extern class Input {
 	/**
 		`joy_connection_changed` signal.
-		
-		Emitted when a joypad device has been connected or disconnected.
 	**/
 	public static var onJoyConnectionChanged(get, never):Signal<(device:Int, connected:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onJoyConnectionChanged():Signal<(device:Int, connected:Bool)->Void> {
@@ -26,10 +24,24 @@ extern class Input {
 	public static var SINGLETON(default, never):godot.Object;
 
 	/**		
-		Returns `true` if you are pressing the key. You can pass a `godot.KeyList` constant.
+		Returns `true` if you are pressing the key in the current keyboard layout. You can pass a `godot.KeyList` constant.
+		
+		`godot.Input.isKeyPressed` is only recommended over `godot.Input.isPhysicalKeyPressed` in non-game applications. This ensures that shortcut keys behave as expected depending on the user's keyboard layout, as keyboard shortcuts are generally dependent on the keyboard layout in non-game applications. If in doubt, use `godot.Input.isPhysicalKeyPressed`.
+		
+		Note: Due to keyboard ghosting, `godot.Input.isKeyPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsKeyPressed")
 	public static function isKeyPressed(scancode:Int):Bool;
+
+	/**		
+		Returns `true` if you are pressing the key in the physical location on the 101/102-key US QWERTY keyboard. You can pass a `godot.KeyList` constant.
+		
+		`godot.Input.isPhysicalKeyPressed` is recommended over `godot.Input.isKeyPressed` for in-game actions, as it will make W/A/S/D layouts work regardless of the user's keyboard layout. `godot.Input.isPhysicalKeyPressed` will also ensure that the top row number keys work on any keyboard layout. If in doubt, use `godot.Input.isPhysicalKeyPressed`.
+		
+		Note: Due to keyboard ghosting, `godot.Input.isPhysicalKeyPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
+	**/
+	@:native("IsPhysicalKeyPressed")
+	public static function isPhysicalKeyPressed(scancode:Int):Bool;
 
 	/**		
 		Returns `true` if you are pressing the mouse button specified with `godot.ButtonList`.
@@ -48,6 +60,8 @@ extern class Input {
 		Returns `true` if you are pressing the action event. Note that if an action has multiple buttons assigned and more than one of them is pressed, releasing one button will release the action, even if some other button assigned to this action is still pressed.
 		
 		If `exact` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.Input.isActionPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionPressed")
 	public static function isActionPressed(action:std.String, ?exact:Bool):Bool;
@@ -56,6 +70,8 @@ extern class Input {
 		Returns `true` if you are pressing the action event. Note that if an action has multiple buttons assigned and more than one of them is pressed, releasing one button will release the action, even if some other button assigned to this action is still pressed.
 		
 		If `exact` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.Input.isActionPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionPressed")
 	public static overload function isActionPressed(action:godot.Action):Bool;
@@ -64,6 +80,8 @@ extern class Input {
 		Returns `true` if you are pressing the action event. Note that if an action has multiple buttons assigned and more than one of them is pressed, releasing one button will release the action, even if some other button assigned to this action is still pressed.
 		
 		If `exact` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.Input.isActionPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionPressed")
 	public static overload function isActionPressed(action:godot.Action, exact:Bool):Bool;
@@ -76,6 +94,8 @@ extern class Input {
 		This is useful for code that needs to run only once when an action is pressed, instead of every frame while it's pressed.
 		
 		If `exact` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.Input.isActionJustPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionJustPressed")
 	public static function isActionJustPressed(action:std.String, ?exact:Bool):Bool;
@@ -86,6 +106,8 @@ extern class Input {
 		This is useful for code that needs to run only once when an action is pressed, instead of every frame while it's pressed.
 		
 		If `exact` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.Input.isActionJustPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionJustPressed")
 	public static overload function isActionJustPressed(action:godot.Action):Bool;
@@ -96,6 +118,8 @@ extern class Input {
 		This is useful for code that needs to run only once when an action is pressed, instead of every frame while it's pressed.
 		
 		If `exact` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.Input.isActionJustPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionJustPressed")
 	public static overload function isActionJustPressed(action:godot.Action, exact:Bool):Bool;
@@ -468,7 +492,9 @@ extern class Input {
 	public static function getMouseMode():godot.Input_MouseMode;
 
 	/**		
-		Sets the mouse position to the specified vector.
+		Sets the mouse position to the specified vector, provided in pixels and relative to an origin at the upper left corner of the game window.
+		
+		Mouse position is clipped to the limits of the screen resolution, or to the limits of the game window if `godot.Input_MouseMode` is set to `godot.Input_MouseMode.confined`.
 	**/
 	@:native("WarpMousePosition")
 	public static function warpMousePosition(to:godot.Vector2):Void;
@@ -635,7 +661,9 @@ extern class Input {
 	/**		
 		Enables or disables the accumulation of similar input events sent by the operating system. When input accumulation is enabled, all input events generated during a frame will be merged and emitted when the frame is done rendering. Therefore, this limits the number of input method calls per second to the rendering FPS.
 		
-		Input accumulation is enabled by default. It can be disabled to get slightly more precise/reactive input at the cost of increased CPU usage. In applications where drawing freehand lines is required, input accumulation should generally be disabled while the user is drawing the line to get results that closely follow the actual input.
+		Input accumulation can be disabled to get slightly more precise/reactive input at the cost of increased CPU usage. In applications where drawing freehand lines is required, input accumulation should generally be disabled while the user is drawing the line to get results that closely follow the actual input.
+		
+		Note: Input accumulation is disabled by default for backward compatibility reasons. It is however recommended to enable it for games which don't require very reactive input, as this will decrease CPU usage.
 	**/
 	@:native("SetUseAccumulatedInput")
 	public static function setUseAccumulatedInput(enable:Bool):Void;

--- a/godot/InputEvent.hx
+++ b/godot/InputEvent.hx
@@ -57,6 +57,8 @@ extern abstract class InputEvent extends godot.Resource {
 		Returns `true` if the given action is being pressed (and is not an echo event for `godot.InputEventKey` events, unless `allow_echo` is `true`). Not relevant for events of type `godot.InputEventMouseMotion` or `godot.InputEventScreenDrag`.
 		
 		If `exact_match` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.InputEvent.isActionPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionPressed")
 	public function isActionPressed(action:std.String, ?allowEcho:Bool, ?exactMatch:Bool):Bool;
@@ -65,6 +67,8 @@ extern abstract class InputEvent extends godot.Resource {
 		Returns `true` if the given action is being pressed (and is not an echo event for `godot.InputEventKey` events, unless `allow_echo` is `true`). Not relevant for events of type `godot.InputEventMouseMotion` or `godot.InputEventScreenDrag`.
 		
 		If `exact_match` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.InputEvent.isActionPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionPressed")
 	public overload function isActionPressed(action:std.String):Bool;
@@ -73,6 +77,8 @@ extern abstract class InputEvent extends godot.Resource {
 		Returns `true` if the given action is being pressed (and is not an echo event for `godot.InputEventKey` events, unless `allow_echo` is `true`). Not relevant for events of type `godot.InputEventMouseMotion` or `godot.InputEventScreenDrag`.
 		
 		If `exact_match` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.InputEvent.isActionPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionPressed")
 	public overload function isActionPressed(action:std.String, allowEcho:Bool):Bool;
@@ -81,6 +87,8 @@ extern abstract class InputEvent extends godot.Resource {
 		Returns `true` if the given action is being pressed (and is not an echo event for `godot.InputEventKey` events, unless `allow_echo` is `true`). Not relevant for events of type `godot.InputEventMouseMotion` or `godot.InputEventScreenDrag`.
 		
 		If `exact_match` is `false`, it ignores the input modifiers for `godot.InputEventKey` and `godot.InputEventMouseButton` events, and the direction for `godot.InputEventJoypadMotion` events.
+		
+		Note: Due to keyboard ghosting, `godot.InputEvent.isActionPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsActionPressed")
 	public overload function isActionPressed(action:std.String, allowEcho:Bool, exactMatch:Bool):Bool;
@@ -140,6 +148,8 @@ extern abstract class InputEvent extends godot.Resource {
 
 	/**		
 		Returns `true` if this input event is pressed. Not relevant for events of type `godot.InputEventMouseMotion` or `godot.InputEventScreenDrag`.
+		
+		Note: Due to keyboard ghosting, `godot.InputEvent.isActionPressed` may return `false` even if one of the action's keys is pressed. See [https://docs.godotengine.org/en/3.4/tutorials/inputs/input_examples.html#keyboard-events](Input examples) in the documentation for more information.
 	**/
 	@:native("IsPressed")
 	public function isPressed():Bool;

--- a/godot/InputEventJoypadButton.hx
+++ b/godot/InputEventJoypadButton.hx
@@ -19,7 +19,7 @@ extern class InputEventJoypadButton extends godot.InputEvent {
 	public var pressed:Bool;
 
 	/**		
-		Represents the pressure the user puts on the button with his finger, if the controller supports it. Ranges from `0` to `1`.
+		Represents the pressure the user puts on the button with their finger, if the controller supports it. Ranges from `0` to `1`.
 	**/
 	@:native("Pressure")
 	public var pressure:Single;

--- a/godot/InputEventMouse.hx
+++ b/godot/InputEventMouse.hx
@@ -13,13 +13,13 @@ Stores general mouse events information.
 @:autoBuild(godot.Godot.buildUserClass())
 extern abstract class InputEventMouse extends godot.InputEventWithModifiers {
 	/**		
-		The global mouse position relative to the current `godot.Viewport` when used in `godot.Control._GuiInput`, otherwise is at 0,0.
+		The global mouse position relative to the current `godot.Viewport`. If used in `godot.Control._GuiInput` and if the current `godot.Control` is not under the mouse, moving it will not update this value.
 	**/
 	@:native("GlobalPosition")
 	public var globalPosition:godot.Vector2;
 
 	/**		
-		The local mouse position relative to the `godot.Viewport`. If used in `godot.Control._GuiInput`, the position is relative to the current `godot.Control` which is under the mouse.
+		The local mouse position relative to the `godot.Viewport`. If used in `godot.Control._GuiInput`, the position is relative to the current `godot.Control` which is under the mouse. If the current `godot.Control` is not under the mouse, moving it will not update this value.
 	**/
 	@:native("Position")
 	public var position:godot.Vector2;

--- a/godot/InputEventMouseMotion.hx
+++ b/godot/InputEventMouseMotion.hx
@@ -7,7 +7,9 @@ import cs.system.*;
 /**
 Contains mouse and pen motion information. Supports relative, absolute positions and speed. See `godot.Node._Input`.
 
-Note: By default, this event is only emitted once per frame rendered at most. If you need more precise input reporting, call `godot.Input.setUseAccumulatedInput` with `false` to make events emitted as often as possible. If you use InputEventMouseMotion to draw lines, consider implementing [https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm](Bresenham's line algorithm) as well to avoid visible gaps in lines if the user is moving the mouse quickly.
+Note: By default, this event can be emitted multiple times per frame rendered, allowing for precise input reporting, at the expense of CPU usage. You can call `godot.Input.setUseAccumulatedInput` with `true` to let multiple events merge into a single emitted event per frame.
+
+Note: If you use InputEventMouseMotion to draw lines, consider implementing [https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm](Bresenham's line algorithm) as well to avoid visible gaps in lines if the user is moving the mouse quickly.
 **/
 @:libType
 @:csNative

--- a/godot/InputMap.hx
+++ b/godot/InputMap.hx
@@ -97,6 +97,8 @@ extern class InputMap {
 
 	/**		
 		Returns an array of `godot.InputEvent`s associated with a given action.
+		
+		Note: When used in the editor (e.g. a tool script or `Godot.EditorPlugin`), this method will return events for the editor action. If you want to access your project's input binds from the editor, read the `input/*` settings from `godot.ProjectSettings`.
 	**/
 	@:native("GetActionList")
 	public static function getActionList(action:std.String):godot.collections.Array;

--- a/godot/ItemList.hx
+++ b/godot/ItemList.hx
@@ -18,8 +18,6 @@ Item text only supports single-line strings, newline characters (e.g. `\n`) in t
 extern class ItemList extends godot.Control {
 	/**
 		`item_activated` signal.
-		
-		Triggered when specified list item is activated via double-clicking or by pressing Enter.
 	**/
 	public var onItemActivated(get, never):Signal<(index:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemActivated():Signal<(index:Int)->Void> {
@@ -28,10 +26,6 @@ extern class ItemList extends godot.Control {
 
 	/**
 		`item_rmb_selected` signal.
-		
-		Triggered when specified list item has been selected via right mouse clicking.
-		The click position is also provided to allow appropriate popup of context menus at the correct location.
-		`allowRmbSelect` must be enabled.
 	**/
 	public var onItemRmbSelected(get, never):Signal<(index:Int, atPosition:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemRmbSelected():Signal<(index:Int, atPosition:Vector2)->Void> {
@@ -40,9 +34,6 @@ extern class ItemList extends godot.Control {
 
 	/**
 		`item_selected` signal.
-		
-		Triggered when specified item has been selected.
-		`allowReselect` must be enabled to reselect an item.
 	**/
 	public var onItemSelected(get, never):Signal<(index:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemSelected():Signal<(index:Int)->Void> {
@@ -51,8 +42,6 @@ extern class ItemList extends godot.Control {
 
 	/**
 		`multi_selected` signal.
-		
-		Triggered when a multiple selection is altered on a list allowing multiple selection.
 	**/
 	public var onMultiSelected(get, never):Signal<(index:Int, selected:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMultiSelected():Signal<(index:Int, selected:Bool)->Void> {
@@ -61,8 +50,6 @@ extern class ItemList extends godot.Control {
 
 	/**
 		`nothing_selected` signal.
-		
-		Triggered when a left mouse click is issued within the rect of the list but on empty space.
 	**/
 	public var onNothingSelected(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNothingSelected():Signal<Void->Void> {
@@ -71,9 +58,6 @@ extern class ItemList extends godot.Control {
 
 	/**
 		`rmb_clicked` signal.
-		
-		Triggered when a right mouse click is issued within the rect of the list but on empty space.
-		`allowRmbSelect` must be enabled.
 	**/
 	public var onRmbClicked(get, never):Signal<(atPosition:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRmbClicked():Signal<(atPosition:Vector2)->Void> {
@@ -550,7 +534,7 @@ extern class ItemList extends godot.Control {
 	public function ensureCurrentIsVisible():Void;
 
 	/**		
-		Returns the `godot.Object` ID associated with the list.
+		Returns the vertical scrollbar.
 		
 		Warning: This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their `godot.CanvasItem.visible` property.
 	**/

--- a/godot/JSON.hx
+++ b/godot/JSON.hx
@@ -21,7 +21,7 @@ extern class JSON {
 		
 		Note: The JSON specification does not define integer or float types, but only a number type. Therefore, converting a Variant to JSON text will convert all numerical values to `Single` types.
 		
-		Use `indent` parameter to pretty print the output.
+		The `indent` parameter controls if and how something is indented, the string used for this parameter will be used where there should be an indent in the output, even spaces like `"   "` will work. `\t` and `\n` can also be used for a tab indent, or to make a newline for each indent respectively.
 		
 		Example output:
 		
@@ -44,6 +44,22 @@ extern class JSON {
 		"value": "value_1"
 		}
 		]
+		}
+		
+		## JSON.print(my_dictionary, "...")
+		{
+		..."name": "my_dictionary",
+		..."version": "1.0.0",
+		..."entities": [
+		......{
+		........."name": "entity_0",
+		........."value": "value_0"
+		......},
+		......{
+		........."name": "entity_1",
+		........."value": "value_1"
+		......}
+		...]
 		}
 		
 		```
@@ -56,7 +72,7 @@ extern class JSON {
 		
 		Note: The JSON specification does not define integer or float types, but only a number type. Therefore, converting a Variant to JSON text will convert all numerical values to `Single` types.
 		
-		Use `indent` parameter to pretty print the output.
+		The `indent` parameter controls if and how something is indented, the string used for this parameter will be used where there should be an indent in the output, even spaces like `"   "` will work. `\t` and `\n` can also be used for a tab indent, or to make a newline for each indent respectively.
 		
 		Example output:
 		
@@ -79,6 +95,22 @@ extern class JSON {
 		"value": "value_1"
 		}
 		]
+		}
+		
+		## JSON.print(my_dictionary, "...")
+		{
+		..."name": "my_dictionary",
+		..."version": "1.0.0",
+		..."entities": [
+		......{
+		........."name": "entity_0",
+		........."value": "value_0"
+		......},
+		......{
+		........."name": "entity_1",
+		........."value": "value_1"
+		......}
+		...]
 		}
 		
 		```
@@ -91,7 +123,7 @@ extern class JSON {
 		
 		Note: The JSON specification does not define integer or float types, but only a number type. Therefore, converting a Variant to JSON text will convert all numerical values to `Single` types.
 		
-		Use `indent` parameter to pretty print the output.
+		The `indent` parameter controls if and how something is indented, the string used for this parameter will be used where there should be an indent in the output, even spaces like `"   "` will work. `\t` and `\n` can also be used for a tab indent, or to make a newline for each indent respectively.
 		
 		Example output:
 		
@@ -114,6 +146,22 @@ extern class JSON {
 		"value": "value_1"
 		}
 		]
+		}
+		
+		## JSON.print(my_dictionary, "...")
+		{
+		..."name": "my_dictionary",
+		..."version": "1.0.0",
+		..."entities": [
+		......{
+		........."name": "entity_0",
+		........."value": "value_0"
+		......},
+		......{
+		........."name": "entity_1",
+		........."value": "value_1"
+		......}
+		...]
 		}
 		
 		```
@@ -126,7 +174,7 @@ extern class JSON {
 		
 		Note: The JSON specification does not define integer or float types, but only a number type. Therefore, converting a Variant to JSON text will convert all numerical values to `Single` types.
 		
-		Use `indent` parameter to pretty print the output.
+		The `indent` parameter controls if and how something is indented, the string used for this parameter will be used where there should be an indent in the output, even spaces like `"   "` will work. `\t` and `\n` can also be used for a tab indent, or to make a newline for each indent respectively.
 		
 		Example output:
 		
@@ -149,6 +197,22 @@ extern class JSON {
 		"value": "value_1"
 		}
 		]
+		}
+		
+		## JSON.print(my_dictionary, "...")
+		{
+		..."name": "my_dictionary",
+		..."version": "1.0.0",
+		..."entities": [
+		......{
+		........."name": "entity_0",
+		........."value": "value_0"
+		......},
+		......{
+		........."name": "entity_1",
+		........."value": "value_1"
+		......}
+		...]
 		}
 		
 		```

--- a/godot/JoystickList.hx
+++ b/godot/JoystickList.hx
@@ -421,7 +421,13 @@ extern enum JoystickList {
 	Touchpad;
 
 	/**		
-		Represents the maximum number of joystick buttons supported.
+		The maximum number of game controller buttons supported by the engine. The actual limit may be lower on specific platforms:
+		
+		- Android: Up to 36 buttons.
+		
+		- Linux: Up to 80 buttons.
+		
+		- Windows and macOS: Up to 128 buttons.
 	**/
 	ButtonMax;
 }

--- a/godot/KinematicBody.hx
+++ b/godot/KinematicBody.hx
@@ -75,7 +75,7 @@ extern class KinematicBody extends godot.PhysicsBody {
 
 	#if doc_gen
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -83,7 +83,7 @@ extern class KinematicBody extends godot.PhysicsBody {
 	public function moveAndCollide(relVec:godot.Vector3, ?infiniteInertia:Bool, ?excludeRaycastShapes:Bool, ?testOnly:Bool):godot.KinematicCollision;
 	#else
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -91,7 +91,7 @@ extern class KinematicBody extends godot.PhysicsBody {
 	public overload function moveAndCollide(relVec:godot.Vector3):godot.KinematicCollision;
 
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -99,7 +99,7 @@ extern class KinematicBody extends godot.PhysicsBody {
 	public overload function moveAndCollide(relVec:godot.Vector3, infiniteInertia:Bool):godot.KinematicCollision;
 
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -107,7 +107,7 @@ extern class KinematicBody extends godot.PhysicsBody {
 	public overload function moveAndCollide(relVec:godot.Vector3, infiniteInertia:Bool, excludeRaycastShapes:Bool):godot.KinematicCollision;
 
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -373,19 +373,25 @@ extern class KinematicBody extends godot.PhysicsBody {
 
 	#if doc_gen
 	/**		
-		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would occur.
+		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would stop the body from moving along the whole path.
+		
+		Use `godot.KinematicBody.moveAndCollide` instead for detecting collision with touching bodies.
 	**/
 	@:native("TestMove")
 	public function testMove(from:godot.Transform, relVec:godot.Vector3, ?infiniteInertia:Bool):Bool;
 	#else
 	/**		
-		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would occur.
+		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would stop the body from moving along the whole path.
+		
+		Use `godot.KinematicBody.moveAndCollide` instead for detecting collision with touching bodies.
 	**/
 	@:native("TestMove")
 	public overload function testMove(from:godot.Transform, relVec:godot.Vector3):Bool;
 
 	/**		
-		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would occur.
+		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would stop the body from moving along the whole path.
+		
+		Use `godot.KinematicBody.moveAndCollide` instead for detecting collision with touching bodies.
 	**/
 	@:native("TestMove")
 	public overload function testMove(from:godot.Transform, relVec:godot.Vector3, infiniteInertia:Bool):Bool;

--- a/godot/KinematicBody2D.hx
+++ b/godot/KinematicBody2D.hx
@@ -39,7 +39,7 @@ extern class KinematicBody2D extends godot.PhysicsBody2D {
 
 	#if doc_gen
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -47,7 +47,7 @@ extern class KinematicBody2D extends godot.PhysicsBody2D {
 	public function moveAndCollide(relVec:godot.Vector2, ?infiniteInertia:Bool, ?excludeRaycastShapes:Bool, ?testOnly:Bool):godot.KinematicCollision2D;
 	#else
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -55,7 +55,7 @@ extern class KinematicBody2D extends godot.PhysicsBody2D {
 	public overload function moveAndCollide(relVec:godot.Vector2):godot.KinematicCollision2D;
 
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -63,7 +63,7 @@ extern class KinematicBody2D extends godot.PhysicsBody2D {
 	public overload function moveAndCollide(relVec:godot.Vector2, infiniteInertia:Bool):godot.KinematicCollision2D;
 
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -71,7 +71,7 @@ extern class KinematicBody2D extends godot.PhysicsBody2D {
 	public overload function moveAndCollide(relVec:godot.Vector2, infiniteInertia:Bool, excludeRaycastShapes:Bool):godot.KinematicCollision2D;
 
 	/**		
-		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision.
+		Moves the body along the vector `rel_vec`. The body will stop if it collides. Returns a `godot.KinematicCollision2D`, which contains information about the collision when stopped, or when touching another body along the motion.
 		
 		If `test_only` is `true`, the body does not move but the would-be collision information is given.
 	**/
@@ -337,19 +337,25 @@ extern class KinematicBody2D extends godot.PhysicsBody2D {
 
 	#if doc_gen
 	/**		
-		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform2D`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would occur.
+		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform2D`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would stop the body from moving along the whole path.
+		
+		Use `godot.KinematicBody2D.moveAndCollide` instead for detecting collision with touching bodies.
 	**/
 	@:native("TestMove")
 	public function testMove(from:godot.Transform2D, relVec:godot.Vector2, ?infiniteInertia:Bool):Bool;
 	#else
 	/**		
-		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform2D`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would occur.
+		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform2D`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would stop the body from moving along the whole path.
+		
+		Use `godot.KinematicBody2D.moveAndCollide` instead for detecting collision with touching bodies.
 	**/
 	@:native("TestMove")
 	public overload function testMove(from:godot.Transform2D, relVec:godot.Vector2):Bool;
 
 	/**		
-		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform2D`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would occur.
+		Checks for collisions without moving the body. Virtually sets the node's position, scale and rotation to that of the given `godot.Transform2D`, then tries to move the body along the vector `rel_vec`. Returns `true` if a collision would stop the body from moving along the whole path.
+		
+		Use `godot.KinematicBody2D.moveAndCollide` instead for detecting collision with touching bodies.
 	**/
 	@:native("TestMove")
 	public overload function testMove(from:godot.Transform2D, relVec:godot.Vector2, infiniteInertia:Bool):Bool;

--- a/godot/Light.hx
+++ b/godot/Light.hx
@@ -25,7 +25,9 @@ extern abstract class Light extends godot.VisualInstance {
 	public var shadowReverseCullFace:Bool;
 
 	/**		
-		Attempts to reduce `godot.Light.shadowBias` gap.
+		Attempts to reduce `godot.Light.shadowBias` gap by rendering screen-space contact shadows. This has a performance impact, especially at higher values.
+		
+		Note: Contact shadows can look broken, so leaving this property to `0.0` is recommended.
 	**/
 	@:native("ShadowContact")
 	public var shadowContact:Single;

--- a/godot/Line2D.hx
+++ b/godot/Line2D.hx
@@ -5,7 +5,7 @@ package godot;
 import cs.system.*;
 
 /**
-A line through several points in 2D space.
+A line through several points in 2D space. Supports varying width and color over the line's length, texturing, and several cap/joint types.
 
 Note: By default, Godot can only draw up to 4,096 polygon points at a time. To increase this limit, open the Project Settings and increase  and .
 **/
@@ -15,9 +15,11 @@ Note: By default, Godot can only draw up to 4,096 polygon points at a time. To i
 @:autoBuild(godot.Godot.buildUserClass())
 extern class Line2D extends godot.Node2D {
 	/**		
-		If `true`, the line's border will be anti-aliased.
+		If `true`, the line's border will attempt to perform antialiasing by drawing thin OpenGL smooth lines on the line's edges.
 		
-		Note: Line2D is not accelerated by batching when being anti-aliased.
+		Note: Line2D is not accelerated by batching if `godot.Line2D.antialiased` is `true`.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent lines and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedLine2D node. That node relies on a texture with custom mipmaps to perform antialiasing. 2D batching is also still supported with those antialiased lines.
 	**/
 	@:native("Antialiased")
 	public var antialiased:Bool;

--- a/godot/LineEdit.hx
+++ b/godot/LineEdit.hx
@@ -52,8 +52,6 @@ On macOS, some extra keyboard shortcuts are available:
 extern class LineEdit extends godot.Control {
 	/**
 		`text_change_rejected` signal.
-		
-		Emitted when appending text that overflows the `maxLength`. The appended text is truncated to fit `maxLength`, and the part that couldn't fit is passed as the `rejected_substring` argument.
 	**/
 	public var onTextChangeRejected(get, never):Signal<(rejectedSubstring:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextChangeRejected():Signal<(rejectedSubstring:std.String)->Void> {
@@ -62,8 +60,6 @@ extern class LineEdit extends godot.Control {
 
 	/**
 		`text_changed` signal.
-		
-		Emitted when the text changes.
 	**/
 	public var onTextChanged(get, never):Signal<(newText:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextChanged():Signal<(newText:std.String)->Void> {
@@ -72,8 +68,6 @@ extern class LineEdit extends godot.Control {
 
 	/**
 		`text_entered` signal.
-		
-		Emitted when the user presses `KEY_ENTER` on the `LineEdit`.
 	**/
 	public var onTextEntered(get, never):Signal<(newText:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextEntered():Signal<(newText:std.String)->Void> {

--- a/godot/MainLoop.hx
+++ b/godot/MainLoop.hx
@@ -53,8 +53,6 @@ print("  Keys typed: %s" % var2str(keys_typed))
 extern class MainLoop extends godot.Object {
 	/**
 		`on_request_permissions_result` signal.
-		
-		Emitted when a user responds to a permission request.
 	**/
 	public var onOnRequestPermissionsResult(get, never):Signal<(permission:std.String, granted:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onOnRequestPermissionsResult():Signal<(permission:std.String, granted:Bool)->Void> {

--- a/godot/MenuButton.hx
+++ b/godot/MenuButton.hx
@@ -18,8 +18,6 @@ See also `godot.BaseButton` which contains common properties and methods associa
 extern class MenuButton extends godot.Button {
 	/**
 		`about_to_show` signal.
-		
-		Emitted when `PopupMenu` of this MenuButton is about to show.
 	**/
 	public var onAboutToShow(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAboutToShow():Signal<Void->Void> {

--- a/godot/MeshDataTool.hx
+++ b/godot/MeshDataTool.hx
@@ -243,7 +243,7 @@ extern class MeshDataTool extends godot.Reference {
 	/**		
 		Returns the specified vertex of the given face.
 		
-		Vertex argument must be 2 or less because faces contain three vertices.
+		Vertex argument must be either 0, 1, or 2 because faces contain three vertices.
 	**/
 	@:native("GetFaceVertex")
 	public function getFaceVertex(idx:Int, vertex:Int):Int;
@@ -251,7 +251,7 @@ extern class MeshDataTool extends godot.Reference {
 	/**		
 		Returns specified edge associated with given face.
 		
-		Edge argument must 2 or less because a face only has three edges.
+		Edge argument must be either 0, 1, or 2 because a face only has three edges.
 	**/
 	@:native("GetFaceEdge")
 	public function getFaceEdge(idx:Int, edge:Int):Int;

--- a/godot/MeshInstance.hx
+++ b/godot/MeshInstance.hx
@@ -5,7 +5,7 @@ package godot;
 import cs.system.*;
 
 /**
-MeshInstance is a node that takes a `godot.Mesh` resource and adds it to the current scenario by creating an instance of it. This is the class most often used to get 3D geometry rendered and can be used to instance a single `godot.Mesh` in many places. This allows to reuse geometry and save on resources. When a `godot.Mesh` has to be instanced more than thousands of times at close proximity, consider using a `godot.MultiMesh` in a `godot.MultiMeshInstance` instead.
+MeshInstance is a node that takes a `godot.Mesh` resource and adds it to the current scenario by creating an instance of it. This is the class most often used to get 3D geometry rendered and can be used to instance a single `godot.Mesh` in many places. This allows reusing geometry, which can save on resources. When a `godot.Mesh` has to be instanced more than thousands of times at close proximity, consider using a `godot.MultiMesh` in a `godot.MultiMeshInstance` instead.
 **/
 @:libType
 @:csNative
@@ -60,19 +60,21 @@ extern class MeshInstance extends godot.GeometryInstance {
 	public function getSkin():godot.Skin;
 
 	/**		
-		Returns the number of surface materials.
+		Returns the number of surface override materials.
 	**/
 	@:native("GetSurfaceMaterialCount")
 	public function getSurfaceMaterialCount():Int;
 
 	/**		
-		Sets the `godot.Material` for a surface of the `godot.Mesh` resource.
+		Sets the override `godot.Material` for the specified surface of the `godot.Mesh` resource. This material is associated with this `godot.MeshInstance` rather than with the `godot.Mesh` resource.
 	**/
 	@:native("SetSurfaceMaterial")
 	public function setSurfaceMaterial(surface:Int, material:godot.Material):Void;
 
 	/**		
-		Returns the `godot.Material` for a surface of the `godot.Mesh` resource.
+		Returns the override `godot.Material` for a surface of the `godot.Mesh` resource.
+		
+		Note: This function only returns override materials associated with this `godot.MeshInstance`. Consider using `godot.MeshInstance.getActiveMaterial` or `godot.Mesh.surfaceGetMaterial` to get materials associated with the `godot.Mesh` resource.
 	**/
 	@:native("GetSurfaceMaterial")
 	public function getSurfaceMaterial(surface:Int):godot.Material;

--- a/godot/MeshInstance2D.hx
+++ b/godot/MeshInstance2D.hx
@@ -14,8 +14,6 @@ Node used for displaying a `godot.Mesh` in 2D. Can be constructed from an existi
 extern class MeshInstance2D extends godot.Node2D {
 	/**
 		`texture_changed` signal.
-		
-		Emitted when the `texture` is changed.
 	**/
 	public var onTextureChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextureChanged():Signal<Void->Void> {
@@ -25,7 +23,7 @@ extern class MeshInstance2D extends godot.Node2D {
 	/**		
 		The normal map that will be used if using the default `godot.CanvasItemMaterial`.
 		
-		Note: Godot expects the normal map to use X+, Y-, and Z+ coordinates. See [http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates](this page) for a comparison of normal map coordinates expected by popular engines.
+		Note: Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates](this page) for a comparison of normal map coordinates expected by popular engines.
 	**/
 	@:native("NormalMap")
 	public var normalMap:godot.Texture;

--- a/godot/MultiMeshInstance2D.hx
+++ b/godot/MultiMeshInstance2D.hx
@@ -16,8 +16,6 @@ Usage is the same as `godot.MultiMeshInstance`.
 extern class MultiMeshInstance2D extends godot.Node2D {
 	/**
 		`texture_changed` signal.
-		
-		Emitted when the `texture` is changed.
 	**/
 	public var onTextureChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextureChanged():Signal<Void->Void> {
@@ -27,7 +25,7 @@ extern class MultiMeshInstance2D extends godot.Node2D {
 	/**		
 		The normal map that will be used if using the default `godot.CanvasItemMaterial`.
 		
-		Note: Godot expects the normal map to use X+, Y-, and Z+ coordinates. See [http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates](this page) for a comparison of normal map coordinates expected by popular engines.
+		Note: Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates](this page) for a comparison of normal map coordinates expected by popular engines.
 	**/
 	@:native("NormalMap")
 	public var normalMap:godot.Texture;

--- a/godot/MultiplayerAPI.hx
+++ b/godot/MultiplayerAPI.hx
@@ -20,8 +20,6 @@ Note: The high-level multiplayer API protocol is an implementation detail and is
 extern class MultiplayerAPI extends godot.Reference {
 	/**
 		`connected_to_server` signal.
-		
-		Emitted when this MultiplayerAPI's `networkPeer` successfully connected to a server. Only emitted on clients.
 	**/
 	public var onConnectedToServer(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectedToServer():Signal<Void->Void> {
@@ -30,8 +28,6 @@ extern class MultiplayerAPI extends godot.Reference {
 
 	/**
 		`connection_failed` signal.
-		
-		Emitted when this MultiplayerAPI's `networkPeer` fails to establish a connection to a server. Only emitted on clients.
 	**/
 	public var onConnectionFailed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectionFailed():Signal<Void->Void> {
@@ -40,8 +36,6 @@ extern class MultiplayerAPI extends godot.Reference {
 
 	/**
 		`network_peer_connected` signal.
-		
-		Emitted when this MultiplayerAPI's `networkPeer` connects with a new peer. ID is the peer ID of the new peer. Clients get notified when other clients connect to the same server. Upon connecting to a server, a client also receives this signal for the server (with ID being 1).
 	**/
 	public var onNetworkPeerConnected(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNetworkPeerConnected():Signal<(id:Int)->Void> {
@@ -50,8 +44,6 @@ extern class MultiplayerAPI extends godot.Reference {
 
 	/**
 		`network_peer_disconnected` signal.
-		
-		Emitted when this MultiplayerAPI's `networkPeer` disconnects from a peer. Clients get notified when other clients disconnect from the same server.
 	**/
 	public var onNetworkPeerDisconnected(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNetworkPeerDisconnected():Signal<(id:Int)->Void> {
@@ -60,8 +52,6 @@ extern class MultiplayerAPI extends godot.Reference {
 
 	/**
 		`network_peer_packet` signal.
-		
-		Emitted when this MultiplayerAPI's `networkPeer` receive a `packet` with custom data (see `sendBytes`). ID is the peer ID of the peer that sent the packet.
 	**/
 	public var onNetworkPeerPacket(get, never):Signal<(id:Int, packet:std.Array<cs.types.UInt8>)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNetworkPeerPacket():Signal<(id:Int, packet:std.Array<cs.types.UInt8>)->Void> {
@@ -70,8 +60,6 @@ extern class MultiplayerAPI extends godot.Reference {
 
 	/**
 		`server_disconnected` signal.
-		
-		Emitted when this MultiplayerAPI's `networkPeer` disconnects from server. Only emitted on clients.
 	**/
 	public var onServerDisconnected(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onServerDisconnected():Signal<Void->Void> {

--- a/godot/NavigationPolygon.hx
+++ b/godot/NavigationPolygon.hx
@@ -26,7 +26,7 @@ Using `godot.NavigationPolygon.addPolygon` and indices of the vertices array.
 var polygon = NavigationPolygon.new()
 var vertices = PoolVector2Array([Vector2(0, 0), Vector2(0, 50), Vector2(50, 50), Vector2(50, 0)])
 polygon.set_vertices(vertices)
-var indices = PoolIntArray(0, 3, 1)
+var indices = PoolIntArray([0, 1, 2, 3])
 polygon.add_polygon(indices)
 $NavigationPolygonInstance.navpoly = polygon
 

--- a/godot/NetworkedMultiplayerPeer.hx
+++ b/godot/NetworkedMultiplayerPeer.hx
@@ -16,8 +16,6 @@ Note: The high-level multiplayer API protocol is an implementation detail and is
 extern abstract class NetworkedMultiplayerPeer extends godot.PacketPeer {
 	/**
 		`connection_failed` signal.
-		
-		Emitted when a connection attempt fails.
 	**/
 	public var onConnectionFailed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectionFailed():Signal<Void->Void> {
@@ -26,8 +24,6 @@ extern abstract class NetworkedMultiplayerPeer extends godot.PacketPeer {
 
 	/**
 		`connection_succeeded` signal.
-		
-		Emitted when a connection attempt succeeds.
 	**/
 	public var onConnectionSucceeded(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectionSucceeded():Signal<Void->Void> {
@@ -36,8 +32,6 @@ extern abstract class NetworkedMultiplayerPeer extends godot.PacketPeer {
 
 	/**
 		`peer_connected` signal.
-		
-		Emitted by the server when a client connects.
 	**/
 	public var onPeerConnected(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPeerConnected():Signal<(id:Int)->Void> {
@@ -46,8 +40,6 @@ extern abstract class NetworkedMultiplayerPeer extends godot.PacketPeer {
 
 	/**
 		`peer_disconnected` signal.
-		
-		Emitted by the server when a client disconnects.
 	**/
 	public var onPeerDisconnected(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPeerDisconnected():Signal<(id:Int)->Void> {
@@ -56,8 +48,6 @@ extern abstract class NetworkedMultiplayerPeer extends godot.PacketPeer {
 
 	/**
 		`server_disconnected` signal.
-		
-		Emitted by clients when the server disconnects.
 	**/
 	public var onServerDisconnected(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onServerDisconnected():Signal<Void->Void> {

--- a/godot/NinePatchRect.hx
+++ b/godot/NinePatchRect.hx
@@ -14,8 +14,6 @@ Also known as 9-slice panels, NinePatchRect produces clean panels of any size, b
 extern class NinePatchRect extends godot.Control {
 	/**
 		`texture_changed` signal.
-		
-		Emitted when the node's texture changes.
 	**/
 	public var onTextureChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextureChanged():Signal<Void->Void> {

--- a/godot/Node.hx
+++ b/godot/Node.hx
@@ -34,8 +34,6 @@ Networking with nodes: After connecting to a server (or making one, see `godot.N
 extern class Node extends godot.Object {
 	/**
 		`ready` signal.
-		
-		Emitted when the node is ready.
 	**/
 	public var onReady(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onReady():Signal<Void->Void> {
@@ -44,8 +42,6 @@ extern class Node extends godot.Object {
 
 	/**
 		`renamed` signal.
-		
-		Emitted when the node is renamed.
 	**/
 	public var onRenamed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRenamed():Signal<Void->Void> {
@@ -54,8 +50,6 @@ extern class Node extends godot.Object {
 
 	/**
 		`tree_entered` signal.
-		
-		Emitted when the node enters the tree.
 	**/
 	public var onTreeEntered(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTreeEntered():Signal<Void->Void> {
@@ -64,8 +58,6 @@ extern class Node extends godot.Object {
 
 	/**
 		`tree_exited` signal.
-		
-		Emitted after the node exits the tree and is no longer active.
 	**/
 	public var onTreeExited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTreeExited():Signal<Void->Void> {
@@ -74,8 +66,6 @@ extern class Node extends godot.Object {
 
 	/**
 		`tree_exiting` signal.
-		
-		Emitted when the node is still active but about to exit the tree. This is the right place for de-initialization (or a "destructor", if you will).
 	**/
 	public var onTreeExiting(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTreeExiting():Signal<Void->Void> {
@@ -102,6 +92,8 @@ extern class Node extends godot.Object {
 
 	/**		
 		The node owner. A node can have any other node as owner (as long as it is a valid parent, grandparent, etc. ascending in the tree). When saving a node (using `godot.PackedScene`), all the nodes it owns will be saved with it. This allows for the creation of complex `godot.SceneTree`s, with instancing and subinstancing.
+		
+		Note: If you want a child to be persisted to a `godot.PackedScene`, you must set `godot.Node.owner` in addition to calling `godot.Node.addChild`. This is typically relevant for [https://docs.godotengine.org/en/3.4/tutorials/misc/running_code_in_the_editor.html](tool scripts) and [https://docs.godotengine.org/en/3.4/tutorials/plugins/editor/index.html](editor plugins). If `godot.Node.addChild` is called without setting `godot.Node.owner`, the newly added `godot.Node` will not be visible in the scene tree, though it will be visible in the 2D/3D view.
 	**/
 	@:native("Owner")
 	public var owner:godot.Node;
@@ -510,7 +502,7 @@ extern class Node extends godot.Object {
 		
 		```
 		
-		Note: If you want a child to be persisted to a `godot.PackedScene`, you must set `godot.Node.owner` in addition to calling `godot.Node.addChild`. This is typically relevant for [https://godot.readthedocs.io/en/3.2/tutorials/misc/running_code_in_the_editor.html](tool scripts) and [https://godot.readthedocs.io/en/latest/tutorials/plugins/editor/index.html](editor plugins). If `godot.Node.addChild` is called without setting `godot.Node.owner`, the newly added `godot.Node` will not be visible in the scene tree, though it will be visible in the 2D/3D view.
+		Note: If you want a child to be persisted to a `godot.PackedScene`, you must set `godot.Node.owner` in addition to calling `godot.Node.addChild`. This is typically relevant for [https://docs.godotengine.org/en/3.4/tutorials/misc/running_code_in_the_editor.html](tool scripts) and [https://docs.godotengine.org/en/3.4/tutorials/plugins/editor/index.html](editor plugins). If `godot.Node.addChild` is called without setting `godot.Node.owner`, the newly added `godot.Node` will not be visible in the scene tree, though it will be visible in the 2D/3D view.
 	**/
 	@:native("AddChild")
 	public function addChild(node:godot.Node, ?legibleUniqueName:Bool):Void;
@@ -530,7 +522,7 @@ extern class Node extends godot.Object {
 		
 		```
 		
-		Note: If you want a child to be persisted to a `godot.PackedScene`, you must set `godot.Node.owner` in addition to calling `godot.Node.addChild`. This is typically relevant for [https://godot.readthedocs.io/en/3.2/tutorials/misc/running_code_in_the_editor.html](tool scripts) and [https://godot.readthedocs.io/en/latest/tutorials/plugins/editor/index.html](editor plugins). If `godot.Node.addChild` is called without setting `godot.Node.owner`, the newly added `godot.Node` will not be visible in the scene tree, though it will be visible in the 2D/3D view.
+		Note: If you want a child to be persisted to a `godot.PackedScene`, you must set `godot.Node.owner` in addition to calling `godot.Node.addChild`. This is typically relevant for [https://docs.godotengine.org/en/3.4/tutorials/misc/running_code_in_the_editor.html](tool scripts) and [https://docs.godotengine.org/en/3.4/tutorials/plugins/editor/index.html](editor plugins). If `godot.Node.addChild` is called without setting `godot.Node.owner`, the newly added `godot.Node` will not be visible in the scene tree, though it will be visible in the 2D/3D view.
 	**/
 	@:native("AddChild")
 	public overload function addChild(node:godot.Node):Void;
@@ -550,7 +542,7 @@ extern class Node extends godot.Object {
 		
 		```
 		
-		Note: If you want a child to be persisted to a `godot.PackedScene`, you must set `godot.Node.owner` in addition to calling `godot.Node.addChild`. This is typically relevant for [https://godot.readthedocs.io/en/3.2/tutorials/misc/running_code_in_the_editor.html](tool scripts) and [https://godot.readthedocs.io/en/latest/tutorials/plugins/editor/index.html](editor plugins). If `godot.Node.addChild` is called without setting `godot.Node.owner`, the newly added `godot.Node` will not be visible in the scene tree, though it will be visible in the 2D/3D view.
+		Note: If you want a child to be persisted to a `godot.PackedScene`, you must set `godot.Node.owner` in addition to calling `godot.Node.addChild`. This is typically relevant for [https://docs.godotengine.org/en/3.4/tutorials/misc/running_code_in_the_editor.html](tool scripts) and [https://docs.godotengine.org/en/3.4/tutorials/plugins/editor/index.html](editor plugins). If `godot.Node.addChild` is called without setting `godot.Node.owner`, the newly added `godot.Node` will not be visible in the scene tree, though it will be visible in the 2D/3D view.
 	**/
 	@:native("AddChild")
 	public overload function addChild(node:godot.Node, legibleUniqueName:Bool):Void;
@@ -638,7 +630,7 @@ extern class Node extends godot.Object {
 
 	#if doc_gen
 	/**		
-		Finds a descendant of this node whose name matches `mask` as in `String.match` (i.e. case-sensitive, but `"*"` matches zero or more characters and `"?"` matches any single character except `"."`).
+		Finds a descendant of this node whose name matches `mask` as in `String.match` (i.e. case-sensitive, but `"*"` matches zero or more characters and `"?"` matches any single character except `"."`). Returns `null` if no matching `godot.Node` is found.
 		
 		Note: It does not match against the full path, just against individual node names.
 		
@@ -650,7 +642,7 @@ extern class Node extends godot.Object {
 	public function findNode(mask:std.String, ?recursive:Bool, ?owned:Bool):godot.Node;
 	#else
 	/**		
-		Finds a descendant of this node whose name matches `mask` as in `String.match` (i.e. case-sensitive, but `"*"` matches zero or more characters and `"?"` matches any single character except `"."`).
+		Finds a descendant of this node whose name matches `mask` as in `String.match` (i.e. case-sensitive, but `"*"` matches zero or more characters and `"?"` matches any single character except `"."`). Returns `null` if no matching `godot.Node` is found.
 		
 		Note: It does not match against the full path, just against individual node names.
 		
@@ -662,7 +654,7 @@ extern class Node extends godot.Object {
 	public overload function findNode(mask:std.String):godot.Node;
 
 	/**		
-		Finds a descendant of this node whose name matches `mask` as in `String.match` (i.e. case-sensitive, but `"*"` matches zero or more characters and `"?"` matches any single character except `"."`).
+		Finds a descendant of this node whose name matches `mask` as in `String.match` (i.e. case-sensitive, but `"*"` matches zero or more characters and `"?"` matches any single character except `"."`). Returns `null` if no matching `godot.Node` is found.
 		
 		Note: It does not match against the full path, just against individual node names.
 		
@@ -674,7 +666,7 @@ extern class Node extends godot.Object {
 	public overload function findNode(mask:std.String, recursive:Bool):godot.Node;
 
 	/**		
-		Finds a descendant of this node whose name matches `mask` as in `String.match` (i.e. case-sensitive, but `"*"` matches zero or more characters and `"?"` matches any single character except `"."`).
+		Finds a descendant of this node whose name matches `mask` as in `String.match` (i.e. case-sensitive, but `"*"` matches zero or more characters and `"?"` matches any single character except `"."`). Returns `null` if no matching `godot.Node` is found.
 		
 		Note: It does not match against the full path, just against individual node names.
 		
@@ -804,6 +796,18 @@ extern class Node extends godot.Object {
 		Returns an array listing the groups that the node is a member of.
 		
 		Note: For performance reasons, the order of node groups is not guaranteed. The order of node groups should not be relied upon as it can vary across project runs.
+		
+		Note: The engine uses some group names internally (all starting with an underscore). To avoid conflicts with internal groups, do not add custom groups whose name starts with an underscore. To exclude internal groups while looping over `godot.Node.getGroups`, use the following snippet:
+		
+		```
+		
+		# Stores the node's non-internal groups only (as an array of Strings).
+		var non_internal_groups = []
+		for group in get_groups():
+		if not group.begins_with("_"):
+		non_internal_groups.push_back(group)
+		
+		```
 	**/
 	@:native("GetGroups")
 	public function getGroups():godot.collections.Array;
@@ -1099,18 +1103,24 @@ extern class Node extends godot.Object {
 	#if doc_gen
 	/**		
 		Replaces a node in a scene by the given one. Subscriptions that pass through this node will be lost.
+		
+		Note that the replaced node is not automatically freed, so you either need to keep it in a variable for later use or free it using `godot.Object.free`.
 	**/
 	@:native("ReplaceBy")
 	public function replaceBy(node:godot.Node, ?keepData:Bool):Void;
 	#else
 	/**		
 		Replaces a node in a scene by the given one. Subscriptions that pass through this node will be lost.
+		
+		Note that the replaced node is not automatically freed, so you either need to keep it in a variable for later use or free it using `godot.Object.free`.
 	**/
 	@:native("ReplaceBy")
 	public overload function replaceBy(node:godot.Node):Void;
 
 	/**		
 		Replaces a node in a scene by the given one. Subscriptions that pass through this node will be lost.
+		
+		Note that the replaced node is not automatically freed, so you either need to keep it in a variable for later use or free it using `godot.Object.free`.
 	**/
 	@:native("ReplaceBy")
 	public overload function replaceBy(node:godot.Node, keepData:Bool):Void;
@@ -1202,7 +1212,7 @@ extern class Node extends godot.Object {
 	public function rsetConfig(property:std.String, mode:godot.MultiplayerAPI_RPCMode):Void;
 
 	/**		
-		Sends a remote procedure call request for the given `method` to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same `godot.NodePath`, including the exact same node name. Behaviour depends on the RPC configuration for the given method, see `godot.Node.rpcConfig`. Methods are not exposed to RPCs by default. See also `godot.Node.rset` and `godot.Node.rsetConfig` for properties. Returns an empty `Variant`.
+		Sends a remote procedure call request for the given `method` to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same `godot.NodePath`, including the exact same node name. Behaviour depends on the RPC configuration for the given method, see `godot.Node.rpcConfig`. Methods are not exposed to RPCs by default. See also `godot.Node.rset` and `godot.Node.rsetConfig` for properties. Returns `null`.
 		
 		Note: You can only safely use RPCs on clients after you received the `connected_to_server` signal from the `godot.SceneTree`. You also need to keep track of the connection state, either by the `godot.SceneTree` signals like `server_disconnected` or by checking `SceneTree.network_peer.get_connection_status() == CONNECTION_CONNECTED`.
 	**/
@@ -1210,19 +1220,19 @@ extern class Node extends godot.Object {
 	public function rpc(method:std.String, args:HaxeArray<Dynamic>):Dynamic;
 
 	/**		
-		Sends a `godot.Node.rpc` using an unreliable protocol. Returns an empty `Variant`.
+		Sends a `godot.Node.rpc` using an unreliable protocol. Returns `null`.
 	**/
 	@:native("RpcUnreliable")
 	public function rpcUnreliable(method:std.String, args:HaxeArray<Dynamic>):Dynamic;
 
 	/**		
-		Sends a `godot.Node.rpc` to a specific peer identified by `peer_id` (see `godot.NetworkedMultiplayerPeer.setTargetPeer`). Returns an empty `Variant`.
+		Sends a `godot.Node.rpc` to a specific peer identified by `peer_id` (see `godot.NetworkedMultiplayerPeer.setTargetPeer`). Returns `null`.
 	**/
 	@:native("RpcId")
 	public function rpcId(peerId:Int, method:std.String, args:HaxeArray<Dynamic>):Dynamic;
 
 	/**		
-		Sends a `godot.Node.rpc` to a specific peer identified by `peer_id` using an unreliable protocol (see `godot.NetworkedMultiplayerPeer.setTargetPeer`). Returns an empty `Variant`.
+		Sends a `godot.Node.rpc` to a specific peer identified by `peer_id` using an unreliable protocol (see `godot.NetworkedMultiplayerPeer.setTargetPeer`). Returns `null`.
 	**/
 	@:native("RpcUnreliableId")
 	public function rpcUnreliableId(peerId:Int, method:std.String, args:HaxeArray<Dynamic>):Dynamic;

--- a/godot/OS.hx
+++ b/godot/OS.hx
@@ -266,19 +266,19 @@ extern class OS {
 
 	#if doc_gen
 	/**		
-		Returns the position of the specified screen by index. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the position of the specified screen by index. If `screen` is `-1` (the default value), the current screen will be used.
 	**/
 	@:native("GetScreenPosition")
 	public static function getScreenPosition(?screen:Int):godot.Vector2;
 	#else
 	/**		
-		Returns the position of the specified screen by index. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the position of the specified screen by index. If `screen` is `-1` (the default value), the current screen will be used.
 	**/
 	@:native("GetScreenPosition")
 	public static overload function getScreenPosition():godot.Vector2;
 
 	/**		
-		Returns the position of the specified screen by index. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the position of the specified screen by index. If `screen` is `-1` (the default value), the current screen will be used.
 	**/
 	@:native("GetScreenPosition")
 	public static overload function getScreenPosition(screen:Int):godot.Vector2;
@@ -286,19 +286,19 @@ extern class OS {
 
 	#if doc_gen
 	/**		
-		Returns the dimensions in pixels of the specified screen. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the dimensions in pixels of the specified screen. If `screen` is `-1` (the default value), the current screen will be used.
 	**/
 	@:native("GetScreenSize")
 	public static function getScreenSize(?screen:Int):godot.Vector2;
 	#else
 	/**		
-		Returns the dimensions in pixels of the specified screen. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the dimensions in pixels of the specified screen. If `screen` is `-1` (the default value), the current screen will be used.
 	**/
 	@:native("GetScreenSize")
 	public static overload function getScreenSize():godot.Vector2;
 
 	/**		
-		Returns the dimensions in pixels of the specified screen. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the dimensions in pixels of the specified screen. If `screen` is `-1` (the default value), the current screen will be used.
 	**/
 	@:native("GetScreenSize")
 	public static overload function getScreenSize(screen:Int):godot.Vector2;
@@ -306,7 +306,7 @@ extern class OS {
 
 	#if doc_gen
 	/**		
-		Returns the dots per inch density of the specified screen. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the dots per inch density of the specified screen. If `screen` is `-1` (the default value), the current screen will be used.
 		
 		Note: On macOS, returned value is inaccurate if fractional display scaling mode is used.
 		
@@ -329,7 +329,7 @@ extern class OS {
 	public static function getScreenDpi(?screen:Int):Int;
 	#else
 	/**		
-		Returns the dots per inch density of the specified screen. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the dots per inch density of the specified screen. If `screen` is `-1` (the default value), the current screen will be used.
 		
 		Note: On macOS, returned value is inaccurate if fractional display scaling mode is used.
 		
@@ -352,7 +352,7 @@ extern class OS {
 	public static overload function getScreenDpi():Int;
 
 	/**		
-		Returns the dots per inch density of the specified screen. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Returns the dots per inch density of the specified screen. If `screen` is `-1` (the default value), the current screen will be used.
 		
 		Note: On macOS, returned value is inaccurate if fractional display scaling mode is used.
 		
@@ -377,7 +377,7 @@ extern class OS {
 
 	#if doc_gen
 	/**		
-		Return the scale factor of the specified screen by index. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Return the scale factor of the specified screen by index. If `screen` is `-1` (the default value), the current screen will be used.
 		
 		Note: On macOS returned value is `2.0` for hiDPI (Retina) screen, and `1.0` for all other cases.
 		
@@ -387,7 +387,7 @@ extern class OS {
 	public static function getScreenScale(?screen:Int):Single;
 	#else
 	/**		
-		Return the scale factor of the specified screen by index. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Return the scale factor of the specified screen by index. If `screen` is `-1` (the default value), the current screen will be used.
 		
 		Note: On macOS returned value is `2.0` for hiDPI (Retina) screen, and `1.0` for all other cases.
 		
@@ -397,7 +397,7 @@ extern class OS {
 	public static overload function getScreenScale():Single;
 
 	/**		
-		Return the scale factor of the specified screen by index. If `screen` is [/code]-1[/code] (the default value), the current screen will be used.
+		Return the scale factor of the specified screen by index. If `screen` is `-1` (the default value), the current screen will be used.
 		
 		Note: On macOS returned value is `2.0` for hiDPI (Retina) screen, and `1.0` for all other cases.
 		
@@ -701,6 +701,12 @@ extern class OS {
 		
 		Note: This method is implemented on Android, iOS, Linux, macOS and Windows.
 		
+		Note: To execute a Windows command interpreter built-in command, specify `cmd.exe` in `path`, `/c` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a PowerShell built-in command, specify `powershell.exe` in `path`, `-Command` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a Unix shell built-in command, specify shell executable name in `path`, `-c` as the first argument, and the desired command as the second argument.
+		
 		@param output If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("Execute")
@@ -745,6 +751,12 @@ extern class OS {
 		```
 		
 		Note: This method is implemented on Android, iOS, Linux, macOS and Windows.
+		
+		Note: To execute a Windows command interpreter built-in command, specify `cmd.exe` in `path`, `/c` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a PowerShell built-in command, specify `powershell.exe` in `path`, `-Command` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a Unix shell built-in command, specify shell executable name in `path`, `-c` as the first argument, and the desired command as the second argument.
 		
 		@param output If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
@@ -791,6 +803,12 @@ extern class OS {
 		
 		Note: This method is implemented on Android, iOS, Linux, macOS and Windows.
 		
+		Note: To execute a Windows command interpreter built-in command, specify `cmd.exe` in `path`, `/c` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a PowerShell built-in command, specify `powershell.exe` in `path`, `-Command` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a Unix shell built-in command, specify shell executable name in `path`, `-c` as the first argument, and the desired command as the second argument.
+		
 		@param output If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("Execute")
@@ -836,6 +854,12 @@ extern class OS {
 		
 		Note: This method is implemented on Android, iOS, Linux, macOS and Windows.
 		
+		Note: To execute a Windows command interpreter built-in command, specify `cmd.exe` in `path`, `/c` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a PowerShell built-in command, specify `powershell.exe` in `path`, `-Command` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a Unix shell built-in command, specify shell executable name in `path`, `-c` as the first argument, and the desired command as the second argument.
+		
 		@param output If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("Execute")
@@ -880,6 +904,12 @@ extern class OS {
 		```
 		
 		Note: This method is implemented on Android, iOS, Linux, macOS and Windows.
+		
+		Note: To execute a Windows command interpreter built-in command, specify `cmd.exe` in `path`, `/c` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a PowerShell built-in command, specify `powershell.exe` in `path`, `-Command` as the first argument, and the desired command as the second argument.
+		
+		Note: To execute a Unix shell built-in command, specify shell executable name in `path`, `-c` as the first argument, and the desired command as the second argument.
 		
 		@param output If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
@@ -969,6 +999,10 @@ extern class OS {
 		if argument.find("=") &gt; -1:
 		var key_value = argument.split("=")
 		arguments[key_value[0].lstrip("--")] = key_value[1]
+		else:
+		# Options without an argument will be present in the dictionary,
+		# with the value set to an empty string.
+		arguments[argument.lstrip("--")] = ""
 		
 		```
 	**/
@@ -1389,7 +1423,7 @@ extern class OS {
 	#end
 
 	/**		
-		Returns the amount of static memory being used by the program in bytes.
+		Returns the amount of static memory being used by the program in bytes (only works in debug).
 	**/
 	@:native("GetStaticMemoryUsage")
 	public static function getStaticMemoryUsage():cs.types.UInt64;
@@ -1625,7 +1659,7 @@ extern class OS {
 	public static function isDeltaSmoothingEnabled():Bool;
 
 	/**		
-		Returns `true` if the feature for the given feature tag is supported in the currently running instance, depending on the platform, build etc. Can be used to check whether you're currently running a debug build, on a certain platform or arch, etc. Refer to the [https://docs.godotengine.org/en/3.4/getting_started/workflow/export/feature_tags.html](Feature Tags) documentation for more details.
+		Returns `true` if the feature for the given feature tag is supported in the currently running instance, depending on the platform, build etc. Can be used to check whether you're currently running a debug build, on a certain platform or arch, etc. Refer to the [https://docs.godotengine.org/en/3.4/tutorials/export/feature_tags.html](Feature Tags) documentation for more details.
 		
 		Note: Tag names are case-sensitive.
 	**/

--- a/godot/Object.hx
+++ b/godot/Object.hx
@@ -40,8 +40,6 @@ Note: Due to a bug, you can't create a "plain" Object using `Object.new()`. Inst
 extern class Object implements cs.system.IDisposable {
 	/**
 		`script_changed` signal.
-		
-		Emitted whenever the object's script is changed.
 	**/
 	public var onScriptChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScriptChanged():Signal<Void->Void> {
@@ -214,7 +212,7 @@ extern class Object implements cs.system.IDisposable {
 	public function isClass(class_:std.String):Bool;
 
 	/**		
-		Assigns a new value to the given property. If the `property` does not exist, nothing will happen.
+		Assigns a new value to the given property. If the `property` does not exist or the given value's type doesn't match, nothing will happen.
 		
 		Note: In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
 	**/
@@ -245,6 +243,8 @@ extern class Object implements cs.system.IDisposable {
 
 	/**		
 		Gets the object's property indexed by the given `godot.NodePath`. The node path should be relative to the current object and can use the colon character (`:`) to access nested properties. Examples: `"position:x"` or `"material:next_pass:blend_mode"`.
+		
+		Note: Even though the method takes `godot.NodePath` argument, it doesn't support actual paths to `godot.Node`s in the scene tree, only colon-separated sub-property paths. For the purpose of nodes, use `godot.Node.getNodeAndResource` instead.
 	**/
 	@:native("GetIndexed")
 	public function getIndexed(property:godot.NodePath):Dynamic;
@@ -479,7 +479,7 @@ extern class Object implements cs.system.IDisposable {
 	/**		
 		Connects a `signal` to a `method` on a `target` object. Pass optional `binds` to the call as an `godot.Collections_Array` of parameters. These parameters will be passed to the method after any parameter used in the call to `godot.Object.emitSignal`. Use `flags` to set deferred or one-shot connections. See `godot.Object_ConnectFlags` constants.
 		
-		A `signal` can only be connected once to a `method`. It will throw an error if already connected, unless the signal was connected with `godot.Object_ConnectFlags.referenceCounted`. To avoid this, first, use `godot.Object.isConnected` to check for existing connections.
+		A `signal` can only be connected once to a `method`. It will print an error if already connected, unless the signal was connected with `godot.Object_ConnectFlags.referenceCounted`. To avoid this, first, use `godot.Object.isConnected` to check for existing connections.
 		
 		If the `target` is destroyed in the game's lifecycle, the connection will be lost.
 		
@@ -512,7 +512,7 @@ extern class Object implements cs.system.IDisposable {
 	/**		
 		Connects a `signal` to a `method` on a `target` object. Pass optional `binds` to the call as an `godot.Collections_Array` of parameters. These parameters will be passed to the method after any parameter used in the call to `godot.Object.emitSignal`. Use `flags` to set deferred or one-shot connections. See `godot.Object_ConnectFlags` constants.
 		
-		A `signal` can only be connected once to a `method`. It will throw an error if already connected, unless the signal was connected with `godot.Object_ConnectFlags.referenceCounted`. To avoid this, first, use `godot.Object.isConnected` to check for existing connections.
+		A `signal` can only be connected once to a `method`. It will print an error if already connected, unless the signal was connected with `godot.Object_ConnectFlags.referenceCounted`. To avoid this, first, use `godot.Object.isConnected` to check for existing connections.
 		
 		If the `target` is destroyed in the game's lifecycle, the connection will be lost.
 		
@@ -545,7 +545,7 @@ extern class Object implements cs.system.IDisposable {
 	/**		
 		Connects a `signal` to a `method` on a `target` object. Pass optional `binds` to the call as an `godot.Collections_Array` of parameters. These parameters will be passed to the method after any parameter used in the call to `godot.Object.emitSignal`. Use `flags` to set deferred or one-shot connections. See `godot.Object_ConnectFlags` constants.
 		
-		A `signal` can only be connected once to a `method`. It will throw an error if already connected, unless the signal was connected with `godot.Object_ConnectFlags.referenceCounted`. To avoid this, first, use `godot.Object.isConnected` to check for existing connections.
+		A `signal` can only be connected once to a `method`. It will print an error if already connected, unless the signal was connected with `godot.Object_ConnectFlags.referenceCounted`. To avoid this, first, use `godot.Object.isConnected` to check for existing connections.
 		
 		If the `target` is destroyed in the game's lifecycle, the connection will be lost.
 		
@@ -578,7 +578,7 @@ extern class Object implements cs.system.IDisposable {
 	/**		
 		Connects a `signal` to a `method` on a `target` object. Pass optional `binds` to the call as an `godot.Collections_Array` of parameters. These parameters will be passed to the method after any parameter used in the call to `godot.Object.emitSignal`. Use `flags` to set deferred or one-shot connections. See `godot.Object_ConnectFlags` constants.
 		
-		A `signal` can only be connected once to a `method`. It will throw an error if already connected, unless the signal was connected with `godot.Object_ConnectFlags.referenceCounted`. To avoid this, first, use `godot.Object.isConnected` to check for existing connections.
+		A `signal` can only be connected once to a `method`. It will print an error if already connected, unless the signal was connected with `godot.Object_ConnectFlags.referenceCounted`. To avoid this, first, use `godot.Object.isConnected` to check for existing connections.
 		
 		If the `target` is destroyed in the game's lifecycle, the connection will be lost.
 		
@@ -612,7 +612,7 @@ extern class Object implements cs.system.IDisposable {
 	/**		
 		Disconnects a `signal` from a `method` on the given `target`.
 		
-		If you try to disconnect a connection that does not exist, the method will throw an error. Use `godot.Object.isConnected` to ensure that the connection exists.
+		If you try to disconnect a connection that does not exist, the method will print an error. Use `godot.Object.isConnected` to ensure that the connection exists.
 	**/
 	@:native("Disconnect")
 	public function disconnect(signal:std.String, target:godot.Object, method:std.String):Void;

--- a/godot/OptionButton.hx
+++ b/godot/OptionButton.hx
@@ -16,8 +16,6 @@ See also `godot.BaseButton` which contains common properties and methods associa
 extern class OptionButton extends godot.Button {
 	/**
 		`item_focused` signal.
-		
-		Emitted when the user navigates to an item using the `ui_up` or `ui_down` actions. The index of the item selected is passed as argument.
 	**/
 	public var onItemFocused(get, never):Signal<(index:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemFocused():Signal<(index:Int)->Void> {
@@ -26,8 +24,6 @@ extern class OptionButton extends godot.Button {
 
 	/**
 		`item_selected` signal.
-		
-		Emitted when the current item has been changed by the user. The index of the item selected is passed as argument.
 	**/
 	public var onItemSelected(get, never):Signal<(index:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemSelected():Signal<(index:Int)->Void> {

--- a/godot/Particles.hx
+++ b/godot/Particles.hx
@@ -11,6 +11,8 @@ Use the `process_material` property to add a `godot.ParticlesMaterial` to config
 
 Note: `godot.Particles` only work when using the GLES3 renderer. If using the GLES2 renderer, use `godot.CPUParticles` instead. You can convert `godot.Particles` to `godot.CPUParticles` by selecting the node, clicking the Particles menu at the top of the 3D editor viewport then choosing Convert to CPUParticles.
 
+Note: On macOS, `godot.Particles` rendering is much slower than `godot.CPUParticles` due to transform feedback being implemented on the CPU instead of the GPU. Consider using `godot.CPUParticles` instead when targeting macOS.
+
 Note: After working on a Particles node, remember to update its `godot.Particles.visibilityAabb` by selecting it, clicking the Particles menu at the top of the 3D editor viewport then choose Generate Visibility AABB. Otherwise, particles may suddenly disappear depending on the camera position and angle.
 **/
 @:libType

--- a/godot/Particles2D.hx
+++ b/godot/Particles2D.hx
@@ -11,6 +11,8 @@ Use the `process_material` property to add a `godot.ParticlesMaterial` to config
 
 Note: `godot.Particles2D` only work when using the GLES3 renderer. If using the GLES2 renderer, use `godot.CPUParticles2D` instead. You can convert `godot.Particles2D` to `godot.CPUParticles2D` by selecting the node, clicking the Particles menu at the top of the 2D editor viewport then choosing Convert to CPUParticles2D.
 
+Note: On macOS, `godot.Particles2D` rendering is much slower than `godot.CPUParticles2D` due to transform feedback being implemented on the CPU instead of the GPU. Consider using `godot.CPUParticles2D` instead when targeting macOS.
+
 Note: After working on a Particles node, remember to update its `godot.Particles2D.visibilityRect` by selecting it, clicking the Particles menu at the top of the 2D editor viewport then choose Generate Visibility Rect. Otherwise, particles may suddenly disappear depending on the camera position and angle.
 
 Note: Unlike `godot.CPUParticles2D`, `godot.Particles2D` currently ignore the texture region defined in `godot.AtlasTexture`s.

--- a/godot/ParticlesMaterial.hx
+++ b/godot/ParticlesMaterial.hx
@@ -115,7 +115,7 @@ extern class ParticlesMaterial extends godot.Material {
 	/**		
 		Initial rotation applied to each particle, in degrees.
 		
-		Only applied when `godot.ParticlesMaterial.flagDisableZ` or `godot.ParticlesMaterial.flagRotateY` are `true` or the `godot.SpatialMaterial` being used to draw the particle is using `godot.SpatialMaterial_BillboardMode.particles`.
+		Note: Only applied when `godot.ParticlesMaterial.flagDisableZ` or `godot.ParticlesMaterial.flagRotateY` are `true` or the `godot.SpatialMaterial` being used to draw the particle is using `godot.SpatialMaterial_BillboardMode.particles`.
 	**/
 	@:native("Angle")
 	public var angle:Single;
@@ -207,7 +207,7 @@ extern class ParticlesMaterial extends godot.Material {
 	/**		
 		Orbital velocity applied to each particle. Makes the particles circle around origin. Specified in number of full rotations around origin per second.
 		
-		Only available when `godot.ParticlesMaterial.flagDisableZ` is `true`.
+		Note: Only available when `godot.ParticlesMaterial.flagDisableZ` is `true`.
 	**/
 	@:native("OrbitVelocity")
 	public var orbitVelocity:Single;
@@ -225,9 +225,9 @@ extern class ParticlesMaterial extends godot.Material {
 	public var angularVelocityRandom:Single;
 
 	/**		
-		Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
+		Initial angular velocity applied to each particle in degrees per second. Sets the speed of rotation of the particle.
 		
-		Only applied when `godot.ParticlesMaterial.flagDisableZ` or `godot.ParticlesMaterial.flagRotateY` are `true` or the `godot.SpatialMaterial` being used to draw the particle is using `godot.SpatialMaterial_BillboardMode.particles`.
+		Note: Only applied when `godot.ParticlesMaterial.flagDisableZ` or `godot.ParticlesMaterial.flagRotateY` are `true` or the `godot.SpatialMaterial` being used to draw the particle is using `godot.SpatialMaterial_BillboardMode.particles`.
 	**/
 	@:native("AngularVelocity")
 	public var angularVelocity:Single;

--- a/godot/Path.hx
+++ b/godot/Path.hx
@@ -16,8 +16,6 @@ Note that the path is considered as relative to the moved nodes (children of `go
 extern class Path extends godot.Spatial {
 	/**
 		`curve_changed` signal.
-		
-		Emitted when the `curve` changes.
 	**/
 	public var onCurveChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCurveChanged():Signal<Void->Void> {

--- a/godot/Physics2DDirectBodyState.hx
+++ b/godot/Physics2DDirectBodyState.hx
@@ -25,13 +25,13 @@ extern abstract class Physics2DDirectBodyState extends godot.Object {
 	public var sleeping:Bool;
 
 	/**		
-		The body's linear velocity.
+		The body's linear velocity in pixels per second.
 	**/
 	@:native("LinearVelocity")
 	public var linearVelocity:godot.Vector2;
 
 	/**		
-		The body's rotational velocity.
+		The body's rotational velocity in radians per second.
 	**/
 	@:native("AngularVelocity")
 	public var angularVelocity:Single;

--- a/godot/Physics2DDirectSpaceState.hx
+++ b/godot/Physics2DDirectSpaceState.hx
@@ -26,7 +26,9 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		`shape`: The shape index of the colliding shape.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
 		
@@ -48,7 +50,9 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		`shape`: The shape index of the colliding shape.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
 		
@@ -70,7 +74,9 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		`shape`: The shape index of the colliding shape.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
 		
@@ -92,7 +98,9 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		`shape`: The shape index of the colliding shape.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
 		
@@ -114,7 +122,9 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		`shape`: The shape index of the colliding shape.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
 		
@@ -136,7 +146,9 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		`shape`: The shape index of the colliding shape.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
 		
@@ -158,7 +170,9 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		`shape`: The shape index of the colliding shape.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
 		
@@ -170,42 +184,168 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 
 	#if doc_gen
 	/**		
+		Checks whether a point is inside any solid shape, in a specific canvas layer given by `canvas_instance_id`. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`metadata`: The intersecting shape's metadata. This metadata is different from `godot.Object.getMeta`, and is set with `godot.Physics2DServer.shapeSetData`.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
+		
+		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
+		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("IntersectPointOnCanvas")
 	public function intersectPointOnCanvas(point:godot.Vector2, canvasInstanceId:cs.types.UInt64, ?maxResults:Int, ?exclude:godot.collections.Array, ?collisionLayer:UInt, ?collideWithBodies:Bool, ?collideWithAreas:Bool):godot.collections.Array;
 	#else
 	/**		
+		Checks whether a point is inside any solid shape, in a specific canvas layer given by `canvas_instance_id`. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`metadata`: The intersecting shape's metadata. This metadata is different from `godot.Object.getMeta`, and is set with `godot.Physics2DServer.shapeSetData`.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
+		
+		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
+		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("IntersectPointOnCanvas")
 	public overload function intersectPointOnCanvas(point:godot.Vector2, canvasInstanceId:cs.types.UInt64):godot.collections.Array;
 
 	/**		
+		Checks whether a point is inside any solid shape, in a specific canvas layer given by `canvas_instance_id`. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`metadata`: The intersecting shape's metadata. This metadata is different from `godot.Object.getMeta`, and is set with `godot.Physics2DServer.shapeSetData`.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
+		
+		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
+		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("IntersectPointOnCanvas")
 	public overload function intersectPointOnCanvas(point:godot.Vector2, canvasInstanceId:cs.types.UInt64, maxResults:Int):godot.collections.Array;
 
 	/**		
+		Checks whether a point is inside any solid shape, in a specific canvas layer given by `canvas_instance_id`. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`metadata`: The intersecting shape's metadata. This metadata is different from `godot.Object.getMeta`, and is set with `godot.Physics2DServer.shapeSetData`.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
+		
+		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
+		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("IntersectPointOnCanvas")
 	public overload function intersectPointOnCanvas(point:godot.Vector2, canvasInstanceId:cs.types.UInt64, maxResults:Int, exclude:godot.collections.Array):godot.collections.Array;
 
 	/**		
+		Checks whether a point is inside any solid shape, in a specific canvas layer given by `canvas_instance_id`. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`metadata`: The intersecting shape's metadata. This metadata is different from `godot.Object.getMeta`, and is set with `godot.Physics2DServer.shapeSetData`.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
+		
+		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
+		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("IntersectPointOnCanvas")
 	public overload function intersectPointOnCanvas(point:godot.Vector2, canvasInstanceId:cs.types.UInt64, maxResults:Int, exclude:godot.collections.Array, collisionLayer:UInt):godot.collections.Array;
 
 	/**		
+		Checks whether a point is inside any solid shape, in a specific canvas layer given by `canvas_instance_id`. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`metadata`: The intersecting shape's metadata. This metadata is different from `godot.Object.getMeta`, and is set with `godot.Physics2DServer.shapeSetData`.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
+		
+		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
+		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("IntersectPointOnCanvas")
 	public overload function intersectPointOnCanvas(point:godot.Vector2, canvasInstanceId:cs.types.UInt64, maxResults:Int, exclude:godot.collections.Array, collisionLayer:UInt, collideWithBodies:Bool):godot.collections.Array;
 
 	/**		
+		Checks whether a point is inside any solid shape, in a specific canvas layer given by `canvas_instance_id`. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`metadata`: The intersecting shape's metadata. This metadata is different from `godot.Object.getMeta`, and is set with `godot.Physics2DServer.shapeSetData`.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
+		
+		Note: `godot.ConcavePolygonShape2D`s and `godot.CollisionPolygon2D`s in `Segments` build mode are not solid shapes. Therefore, they will not be detected.
+		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
 	@:native("IntersectPointOnCanvas")
@@ -232,7 +372,7 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		If the ray did not intersect anything, then an empty dictionary is returned instead.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
@@ -258,7 +398,7 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		If the ray did not intersect anything, then an empty dictionary is returned instead.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
@@ -284,7 +424,7 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		If the ray did not intersect anything, then an empty dictionary is returned instead.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
@@ -310,7 +450,7 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		If the ray did not intersect anything, then an empty dictionary is returned instead.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
@@ -336,7 +476,7 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		If the ray did not intersect anything, then an empty dictionary is returned instead.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/
@@ -362,7 +502,7 @@ extern abstract class Physics2DDirectSpaceState extends godot.Object {
 		
 		If the ray did not intersect anything, then an empty dictionary is returned instead.
 		
-		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody2D`s or `godot.Area2D`s, respectively.
 		
 		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
 	**/

--- a/godot/Physics2DServer.hx
+++ b/godot/Physics2DServer.hx
@@ -630,7 +630,7 @@ extern class Physics2DServer {
 	#end
 
 	/**		
-		Returns the `godot.Physics2DDirectBodyState` of the body.
+		Returns the `godot.Physics2DDirectBodyState` of the body. Returns `null` if the body is destroyed or removed from the physics space.
 	**/
 	@:native("BodyGetDirectState")
 	public static function bodyGetDirectState(body:godot.RID):godot.Physics2DDirectBodyState;

--- a/godot/PhysicsDirectBodyState.hx
+++ b/godot/PhysicsDirectBodyState.hx
@@ -25,13 +25,13 @@ extern abstract class PhysicsDirectBodyState extends godot.Object {
 	public var sleeping:Bool;
 
 	/**		
-		The body's linear velocity.
+		The body's linear velocity in units per second.
 	**/
 	@:native("LinearVelocity")
 	public var linearVelocity:godot.Vector3;
 
 	/**		
-		The body's rotational velocity.
+		The body's rotational velocity in axis-angle format. The magnitude of the vector is the rotation rate in radians per second.
 	**/
 	@:native("AngularVelocity")
 	public var angularVelocity:godot.Vector3;

--- a/godot/PhysicsDirectSpaceState.hx
+++ b/godot/PhysicsDirectSpaceState.hx
@@ -14,6 +14,148 @@ Direct access object to a space in the `godot.PhysicsServer`. It's used mainly t
 extern abstract class PhysicsDirectSpaceState extends godot.Object {
 	#if doc_gen
 	/**		
+		Checks whether a point is inside any solid shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		
+		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
+	**/
+	@:native("IntersectPoint")
+	public function intersectPoint(point:godot.Vector3, ?maxResults:Int, ?exclude:godot.collections.Array, ?collisionLayer:UInt, ?collideWithBodies:Bool, ?collideWithAreas:Bool):godot.collections.Array;
+	#else
+	/**		
+		Checks whether a point is inside any solid shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		
+		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
+	**/
+	@:native("IntersectPoint")
+	public overload function intersectPoint(point:godot.Vector3):godot.collections.Array;
+
+	/**		
+		Checks whether a point is inside any solid shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		
+		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
+	**/
+	@:native("IntersectPoint")
+	public overload function intersectPoint(point:godot.Vector3, maxResults:Int):godot.collections.Array;
+
+	/**		
+		Checks whether a point is inside any solid shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		
+		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
+	**/
+	@:native("IntersectPoint")
+	public overload function intersectPoint(point:godot.Vector3, maxResults:Int, exclude:godot.collections.Array):godot.collections.Array;
+
+	/**		
+		Checks whether a point is inside any solid shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		
+		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
+	**/
+	@:native("IntersectPoint")
+	public overload function intersectPoint(point:godot.Vector3, maxResults:Int, exclude:godot.collections.Array, collisionLayer:UInt):godot.collections.Array;
+
+	/**		
+		Checks whether a point is inside any solid shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		
+		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
+	**/
+	@:native("IntersectPoint")
+	public overload function intersectPoint(point:godot.Vector3, maxResults:Int, exclude:godot.collections.Array, collisionLayer:UInt, collideWithBodies:Bool):godot.collections.Array;
+
+	/**		
+		Checks whether a point is inside any solid shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+		
+		`collider`: The colliding object.
+		
+		`collider_id`: The colliding object's ID.
+		
+		`rid`: The intersecting object's `godot.RID`.
+		
+		`shape`: The shape index of the colliding shape.
+		
+		The number of intersections can be limited with the `max_results` parameter, to reduce the processing time.
+		
+		Additionally, the method can take an `exclude` array of objects or `godot.RID`s that are to be excluded from collisions, a `collision_mask` bitmask representing the physics layers to check in, or booleans to determine if the ray should collide with `godot.PhysicsBody`s or `godot.Area`s, respectively.
+		
+		@param exclude If the parameter is null, then the default value is new Godot.Collections.Array { }
+	**/
+	@:native("IntersectPoint")
+	public overload function intersectPoint(point:godot.Vector3, maxResults:Int, exclude:godot.collections.Array, collisionLayer:UInt, collideWithBodies:Bool, collideWithAreas:Bool):godot.collections.Array;
+	#end
+
+	#if doc_gen
+	/**		
 		Intersects a ray in a given space. The returned object is a dictionary with the following fields:
 		
 		`collider`: The colliding object.

--- a/godot/PhysicsServer.hx
+++ b/godot/PhysicsServer.hx
@@ -336,8 +336,6 @@ extern class PhysicsServer {
 
 	/**		
 		Returns the physics layer or layers a body can collide with.
-		
-		-
 	**/
 	@:native("BodyGetCollisionMask")
 	public static function bodyGetCollisionMask(body:godot.RID):UInt;
@@ -626,7 +624,7 @@ extern class PhysicsServer {
 	#end
 
 	/**		
-		Returns the `godot.PhysicsDirectBodyState` of the body.
+		Returns the `godot.PhysicsDirectBodyState` of the body. Returns `null` if the body is destroyed or removed from the physics space.
 	**/
 	@:native("BodyGetDirectState")
 	public static function bodyGetDirectState(body:godot.RID):godot.PhysicsDirectBodyState;
@@ -808,7 +806,7 @@ extern class PhysicsServer {
 	public static function setCollisionIterations(iterations:Int):Void;
 
 	/**		
-		Returns an Info defined by the `godot.PhysicsServer_ProcessInfo` input given.
+		Returns information about the current state of the 3D physics engine. See `godot.PhysicsServer_ProcessInfo` for a list of available states. Only implemented for Godot Physics.
 	**/
 	@:native("GetProcessInfo")
 	public static function getProcessInfo(processInfo:godot.PhysicsServer_ProcessInfo):Int;

--- a/godot/Polygon2D.hx
+++ b/godot/Polygon2D.hx
@@ -89,7 +89,9 @@ extern class Polygon2D extends godot.Node2D {
 	public var texture:godot.Texture;
 
 	/**		
-		If `true`, polygon edges will be anti-aliased.
+		If `true`, attempts to perform antialiasing for polygon edges by drawing a thin OpenGL smooth line on the edges.
+		
+		Note: Due to how it works, built-in antialiasing will not look correct for translucent polygons and may not work on certain platforms. As a workaround, install the [https://github.com/godot-extended-libraries/godot-antialiased-line2d](Antialiased Line2D) add-on then create an AntialiasedPolygon2D node. That node relies on a texture with custom mipmaps to perform antialiasing.
 	**/
 	@:native("Antialiased")
 	public var antialiased:Bool;

--- a/godot/Popup.hx
+++ b/godot/Popup.hx
@@ -14,8 +14,6 @@ Popup is a base `godot.Control` used to show dialogs and popups. It's a subwindo
 extern class Popup extends godot.Control {
 	/**
 		`about_to_show` signal.
-		
-		Emitted when a popup is about to be shown. This is often used in `PopupMenu` to clear the list of options then create a new one according to the current context.
 	**/
 	public var onAboutToShow(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onAboutToShow():Signal<Void->Void> {
@@ -24,8 +22,6 @@ extern class Popup extends godot.Control {
 
 	/**
 		`popup_hide` signal.
-		
-		Emitted when a popup is hidden.
 	**/
 	public var onPopupHide(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPopupHide():Signal<Void->Void> {

--- a/godot/PopupMenu.hx
+++ b/godot/PopupMenu.hx
@@ -14,8 +14,6 @@ import cs.system.*;
 extern class PopupMenu extends godot.Popup {
 	/**
 		`id_focused` signal.
-		
-		Emitted when user navigated to an item of some `id` using `ui_up` or `ui_down` action.
 	**/
 	public var onIdFocused(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onIdFocused():Signal<(id:Int)->Void> {
@@ -24,8 +22,6 @@ extern class PopupMenu extends godot.Popup {
 
 	/**
 		`id_pressed` signal.
-		
-		Emitted when an item of some `id` is pressed or its accelerator is activated.
 	**/
 	public var onIdPressed(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onIdPressed():Signal<(id:Int)->Void> {
@@ -34,8 +30,6 @@ extern class PopupMenu extends godot.Popup {
 
 	/**
 		`index_pressed` signal.
-		
-		Emitted when an item of some `index` is pressed or its accelerator is activated.
 	**/
 	public var onIndexPressed(get, never):Signal<(index:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onIndexPressed():Signal<(index:Int)->Void> {

--- a/godot/ProjectSettings.hx
+++ b/godot/ProjectSettings.hx
@@ -9,9 +9,9 @@ Contains global variables accessible from everywhere. Use `godot.ProjectSettings
 
 When naming a Project Settings property, use the full path to the setting including the category. For example, `"application/config/name"` for the project name. Category and property names can be viewed in the Project Settings dialog.
 
-Feature tags: Project settings can be overridden for specific platforms and configurations (debug, release, ...) using [https://docs.godotengine.org/en/latest/tutorials/export/feature_tags.html](feature tags).
+Feature tags: Project settings can be overridden for specific platforms and configurations (debug, release, ...) using [https://docs.godotengine.org/en/3.4/tutorials/export/feature_tags.html](feature tags).
 
-Overriding: Any project setting can be overridden by creating a file named `override.cfg` in the project's root directory. This can also be used in exported projects by placing this file in the same directory as the project binary. Overriding will still take the base project settings' [https://docs.godotengine.org/en/latest/tutorials/export/feature_tags.html](feature tags) in account. Therefore, make sure to also override the setting with the desired feature tags if you want them to override base project settings on all platforms and configurations.
+Overriding: Any project setting can be overridden by creating a file named `override.cfg` in the project's root directory. This can also be used in exported projects by placing this file in the same directory as the project binary. Overriding will still take the base project settings' [https://docs.godotengine.org/en/3.4/tutorials/export/feature_tags.html](feature tags) in account. Therefore, make sure to also override the setting with the desired feature tags if you want them to override base project settings on all platforms and configurations.
 **/
 @:libType
 @:csNative
@@ -37,6 +37,8 @@ extern class ProjectSettings {
 		ProjectSettings.set_setting("application/config/name", "Example")
 		
 		```
+		
+		This can also be used to erase custom project settings. To do this change the setting value to `null`.
 	**/
 	@:native("SetSetting")
 	public static function setSetting(name:std.String, value:Dynamic):Void;

--- a/godot/PropertyHint.hx
+++ b/godot/PropertyHint.hx
@@ -21,7 +21,9 @@ extern enum PropertyHint {
 	ExpRange;
 
 	/**		
-		Hints that an integer, float or string property is an enumerated value to pick in a list specified via a hint string such as `"Hello,Something,Else"`.
+		Hints that an integer, float or string property is an enumerated value to pick in a list specified via a hint string.
+		
+		The hint string is a comma separated list of names such as `"Hello,Something,Else"`. For integer and float properties, the first name in the list has value 0, the next 1, and so on. Explicit values can also be specified by appending `:integer` to the name, e.g. `"Zero,One,Three:3,Four,Six:6"`.
 	**/
 	Enum;
 

--- a/godot/ProximityGroup.hx
+++ b/godot/ProximityGroup.hx
@@ -5,7 +5,42 @@ package godot;
 import cs.system.*;
 
 /**
-General-purpose proximity detection node.
+General-purpose proximity detection node. `godot.ProximityGroup` can be used for approximate distance checks, which are faster than exact distance checks using `Vector3.distance_to` or `Vector3.distance_squared_to`.
+
+`godot.ProximityGroup` nodes are automatically grouped together, as long as they share the same `godot.ProximityGroup.groupName` and intersect with each other. By calling the `godot.ProximityGroup.broadcast`, you can invoke a specified method with various parameters to all intersecting members.
+
+`godot.ProximityGroup` is cuboid-shaped and consists of a cluster of `godot.Vector3` coordinates. The coordinates are automatically calculated by calling `godot.ProximityGroup.gridRadius`. To allow `godot.ProximityGroup` to find its peers (and perform automatic grouping), you need to define its `godot.ProximityGroup.groupName` to a non-empty `String`. As soon as this object's shape intersects with another `godot.ProximityGroup` object' shape, and both share the same `godot.ProximityGroup.groupName`, they will belong together for as long as they intersect.
+
+Since `godot.ProximityGroup` doesn't rely the physics engine, you don't need to add any other node as a child (unlike `godot.PhysicsBody`).
+
+The `godot.ProximityGroup` uses the `godot.SceneTree` groups in the background by calling the method `godot.Node.addToGroup` internally. The `godot.SceneTree` group names are constructed by combining the `godot.ProximityGroup.groupName` with its coordinates, which are calculated using the `godot.ProximityGroup.gridRadius` you defined beforehand.
+
+Example: A `godot.ProximityGroup` node named `"PlanetEarth"` at position `Vector3(6, 6, 6)` with a `godot.ProximityGroup.groupName` set to `"planets"` and a `godot.ProximityGroup.gridRadius` of `Vector3(1, 2, 3)` will create the following `godot.SceneTree` group names:
+
+```
+
+- "planets|5|4|3"
+- "planets|5|4|4"
+- "planets|5|4|5"
+- "planets|5|4|6"
+- "planets|5|4|7"
+- "planets|5|4|8"
+- "planets|5|4|9"
+- ...
+
+```
+
+If there is another `godot.ProximityGroup` named `"PlanetMars"` with group name `"planets"`, and one of its coordinates is `Vector3(5, 4, 7)`, it would normally create the `godot.SceneTree` group called `"planets|5|4|7"`. However, since this group name already exists, this `godot.ProximityGroup` object will be added to the existing one. `"PlanetEarth"` is already in this group. As long as both nodes don't change their transform and stop intersecting (or exit the scene tree), they are grouped together. As long as this intersection exists, any call to `godot.ProximityGroup.broadcast` will affect both `godot.ProximityGroup` nodes.
+
+There are 3 caveats to keep in mind when using `godot.ProximityGroup`:
+
+- The larger the grid radius, the more coordinates and the more `godot.SceneTree` groups are created. This can have a performance impact if too many groups are created.
+
+- If the `godot.ProximityGroup` node is transformed in any way (or is removed from the scene tree), the groupings will have to be recalculated. This can also have a performance impact.
+
+- If your `godot.ProximityGroup.gridRadius` is smaller than `Vector3(1, 1, 1)`, it will be rounded up to `Vector3(1, 1, 1)`. Therefore, small grid radius values may lead to unwanted groupings.
+
+Note: `godot.ProximityGroup` will be removed in Godot 4.0 in favor of more effective and faster `godot.VisibilityNotifier` functionality. For most use cases, `Vector3.distance_to` or `Vector3.distance_squared_to` are fast enough too, especially if you call them less often using a `godot.Timer` node.
 **/
 @:libType
 @:csNative
@@ -20,12 +55,23 @@ extern class ProximityGroup extends godot.Spatial {
 		return new Signal(this, "broadcast", Signal.SignalHandlerStringArrayVoid.connectSignal, Signal.SignalHandlerStringArrayVoid.disconnectSignal, Signal.SignalHandlerStringArrayVoid.isSignalConnected);
 	}
 
+	/**		
+		The size of the space in 3D units. This also sets the amount of coordinates required to calculate whether two `godot.ProximityGroup` nodes are intersecting or not. Smaller `godot.ProximityGroup.gridRadius` values can be used for more precise proximity checks at the cost of performance, since more groups will be created.
+	**/
 	@:native("GridRadius")
 	public var gridRadius:godot.Vector3;
 
+	/**		
+		Specifies which node gets contacted on a call of method `godot.ProximityGroup.broadcast`.
+	**/
 	@:native("DispatchMode")
 	public var dispatchMode:godot.ProximityGroup_DispatchModeEnum;
 
+	/**		
+		Specify the common group name, to let other `godot.ProximityGroup` nodes know, if they should be auto-grouped with this node in case they intersect with each other.
+		
+		For example, if you have a `godot.ProximityGroup` node named `"Earth"` and another called `"Mars"`, with both nodes having `"planet"` as their `godot.ProximityGroup.groupName`. Give both planets a significantly larger `godot.ProximityGroup.gridRadius` than their actual radius, position them close enough and they'll be automatically grouped.
+	**/
 	@:native("GroupName")
 	public var groupName:std.String;
 
@@ -50,6 +96,11 @@ extern class ProximityGroup extends godot.Spatial {
 	@:native("GetGridRadius")
 	public function getGridRadius():godot.Vector3;
 
+	/**		
+		Calls on all intersecting `godot.ProximityGroup` the given method and parameters.
+		
+		If the `godot.ProximityGroup.dispatchMode` is set to `godot.ProximityGroup_DispatchModeEnum.proxy` (the default), all calls are delegated to their respective parent `godot.Node`.
+	**/
 	@:native("Broadcast")
 	public function broadcast(method:std.String, parameters:Dynamic):Void;
 }

--- a/godot/ProximityGroup_DispatchModeEnum.hx
+++ b/godot/ProximityGroup_DispatchModeEnum.hx
@@ -5,7 +5,13 @@ package godot;
 @:native("Godot.ProximityGroup.DispatchModeEnum")
 @:csNative
 extern enum ProximityGroup_DispatchModeEnum {
+	/**		
+		This `godot.ProximityGroup`'s parent will be target of `godot.ProximityGroup.broadcast`.
+	**/
 	Proxy;
 
+	/**		
+		This `godot.ProximityGroup` will emit the `broadcast` signal when calling the `godot.ProximityGroup.broadcast` method.
+	**/
 	Signal;
 }

--- a/godot/Range.hx
+++ b/godot/Range.hx
@@ -14,8 +14,6 @@ Range is a base class for `godot.Control` nodes that change a floating-point val
 extern abstract class Range extends godot.Control {
 	/**
 		`changed` signal.
-		
-		Emitted when `minValue`, `maxValue`, `page`, or `step` change.
 	**/
 	public var onChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onChanged():Signal<Void->Void> {
@@ -24,8 +22,6 @@ extern abstract class Range extends godot.Control {
 
 	/**
 		`value_changed` signal.
-		
-		Emitted when `value` changes.
 	**/
 	public var onValueChanged(get, never):Signal<(value:Float)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onValueChanged():Signal<(value:Float)->Void> {
@@ -153,13 +149,13 @@ extern abstract class Range extends godot.Control {
 	public function isLesserAllowed():Bool;
 
 	/**		
-		Binds two ranges together along with any ranges previously grouped with either of them. When any of range's member variables change, it will share the new value with all other ranges in its group.
+		Binds two `godot.Range`s together along with any ranges previously grouped with either of them. When any of range's member variables change, it will share the new value with all other ranges in its group.
 	**/
 	@:native("Share")
 	public function share(with:godot.Node):Void;
 
 	/**		
-		Stops range from sharing its member variables with any other.
+		Stops the `godot.Range` from sharing its member variables with any other.
 	**/
 	@:native("Unshare")
 	public function unshare():Void;

--- a/godot/RayCast.hx
+++ b/godot/RayCast.hx
@@ -24,7 +24,7 @@ extern class RayCast extends godot.Spatial {
 		If set to `1`, a line is used as the debug shape. Otherwise, a truncated pyramid is drawn to represent the `godot.RayCast`. Requires Visible Collision Shapes to be enabled in the Debug menu for the debug shape to be visible at run-time.
 	**/
 	@:native("DebugShapeThickness")
-	public var debugShapeThickness:Single;
+	public var debugShapeThickness:Int;
 
 	/**		
 		The custom color to use to draw the shape in the editor and at run-time if Visible Collision Shapes is enabled in the Debug menu. This color will be highlighted at run-time if the `godot.RayCast` is colliding with something.
@@ -204,8 +204,8 @@ extern class RayCast extends godot.Spatial {
 	public function getDebugShapeCustomColor():godot.Color;
 
 	@:native("SetDebugShapeThickness")
-	public function setDebugShapeThickness(debugShapeThickness:Single):Void;
+	public function setDebugShapeThickness(debugShapeThickness:Int):Void;
 
 	@:native("GetDebugShapeThickness")
-	public function getDebugShapeThickness():Single;
+	public function getDebugShapeThickness():Int;
 }

--- a/godot/ReflectionProbe.hx
+++ b/godot/ReflectionProbe.hx
@@ -7,9 +7,11 @@ import cs.system.*;
 /**
 Capture its surroundings as a dual paraboloid image, and stores versions of it with increasing levels of blur to simulate different material roughnesses.
 
-The `godot.ReflectionProbe` is used to create high-quality reflections at the cost of performance. It can be combined with `godot.GIProbe`s and Screen Space Reflections to achieve high quality reflections. `godot.ReflectionProbe`s render all objects within their `godot.ReflectionProbe.cullMask`, so updating them can be quite expensive. It is best to update them once with the important static objects and then leave them.
+The `godot.ReflectionProbe` is used to create high-quality reflections at a low performance cost (when `godot.ReflectionProbe.updateMode` is `godot.ReflectionProbe_UpdateModeEnum.once`). `godot.ReflectionProbe`s can be blended together and with the rest of the scene smoothly. `godot.ReflectionProbe`s can also be combined with `godot.GIProbe` and screen-space reflections (`godot.Environment.ssReflectionsEnabled`) to get more accurate reflections in specific areas. `godot.ReflectionProbe`s render all objects within their `godot.ReflectionProbe.cullMask`, so updating them can be quite expensive. It is best to update them once with the important static objects and then leave them as-is.
 
-Note: By default Godot will only render 16 reflection probes. If you need more, increase the number of atlas subdivisions. This setting can be found in .
+Note: Unlike `godot.GIProbe`, `godot.ReflectionProbe`s only source their environment from a `godot.WorldEnvironment` node. If you specify an `godot.Environment` resource within a `godot.Camera` node, it will be ignored by the `godot.ReflectionProbe`. This can lead to incorrect lighting within the `godot.ReflectionProbe`.
+
+Note: By default, Godot will only render 16 reflection probes. If you need more, increase the number of atlas subdivisions. This setting can be found in .
 
 Note: The GLES2 backend will only display two reflection probes at the same time for a single mesh. If possible, split up large meshes that span over multiple reflection probes into smaller ones.
 **/
@@ -43,7 +45,7 @@ extern class ReflectionProbe extends godot.VisualInstance {
 	public var interiorEnable:Bool;
 
 	/**		
-		Sets the cull mask which determines what objects are drawn by this probe. Every `godot.VisualInstance` with a layer included in this cull mask will be rendered by the probe. It is best to only include large objects which are likely to take up a lot of space in the reflection in order to save on rendering cost.
+		Sets the cull mask which determines what objects are drawn by this probe. Every `godot.VisualInstance` with a layer included in this cull mask will be rendered by the probe. To improve performance, it is best to only include large objects which are likely to take up a lot of space in the reflection.
 	**/
 	@:native("CullMask")
 	public var cullMask:UInt;
@@ -56,24 +58,30 @@ extern class ReflectionProbe extends godot.VisualInstance {
 
 	/**		
 		If `true`, enables box projection. This makes reflections look more correct in rectangle-shaped rooms by offsetting the reflection center depending on the camera's location.
+		
+		Note: To better fit rectangle-shaped rooms that are not aligned to the grid, you can rotate the `godot.ReflectionProbe` node.
 	**/
 	@:native("BoxProjection")
 	public var boxProjection:Bool;
 
 	/**		
-		Sets the origin offset to be used when this reflection probe is in box project mode.
+		Sets the origin offset to be used when this `godot.ReflectionProbe` is in `godot.ReflectionProbe.boxProjection` mode. This can be set to a non-zero value to ensure a reflection fits a rectangle-shaped room, while reducing the amount of objects that "get in the way" of the reflection.
 	**/
 	@:native("OriginOffset")
 	public var originOffset:godot.Vector3;
 
 	/**		
 		The size of the reflection probe. The larger the extents the more space covered by the probe which will lower the perceived resolution. It is best to keep the extents only as large as you need them.
+		
+		Note: To better fit areas that are not aligned to the grid, you can rotate the `godot.ReflectionProbe` node.
 	**/
 	@:native("Extents")
 	public var extents:godot.Vector3;
 
 	/**		
-		Sets the max distance away from the probe an object can be before it is culled.
+		The maximum distance away from the `godot.ReflectionProbe` an object can be before it is culled. Decrease this to improve performance, especially when using the `godot.ReflectionProbe_UpdateModeEnum.always` `godot.ReflectionProbe.updateMode`.
+		
+		Note: The maximum reflection distance is always at least equal to the `godot.ReflectionProbe.extents`. This means that decreasing `godot.ReflectionProbe.maxDistance` will not always cull objects from reflections, especially if the reflection probe's `godot.ReflectionProbe.extents` are already large.
 	**/
 	@:native("MaxDistance")
 	public var maxDistance:Single;
@@ -85,7 +93,7 @@ extern class ReflectionProbe extends godot.VisualInstance {
 	public var intensity:Single;
 
 	/**		
-		Sets how frequently the probe is updated. Can be `godot.ReflectionProbe_UpdateModeEnum.once` or `godot.ReflectionProbe_UpdateModeEnum.always`.
+		Sets how frequently the `godot.ReflectionProbe` is updated. Can be `godot.ReflectionProbe_UpdateModeEnum.once` or `godot.ReflectionProbe_UpdateModeEnum.always`.
 	**/
 	@:native("UpdateMode")
 	public var updateMode:godot.ReflectionProbe_UpdateModeEnum;

--- a/godot/ReflectionProbe_UpdateModeEnum.hx
+++ b/godot/ReflectionProbe_UpdateModeEnum.hx
@@ -6,12 +6,12 @@ package godot;
 @:csNative
 extern enum ReflectionProbe_UpdateModeEnum {
 	/**		
-		Update the probe once on the next frame.
+		Update the probe once on the next frame (recommended for most objects). The corresponding radiance map will be generated over the following six frames. This takes more time to update than `godot.ReflectionProbe_UpdateModeEnum.always`, but it has a lower performance cost and can result in higher-quality reflections. The ReflectionProbe is updated when its transform changes, but not when nearby geometry changes. You can force a `godot.ReflectionProbe` update by moving the `godot.ReflectionProbe` slightly in any direction.
 	**/
 	Once;
 
 	/**		
-		Update the probe every frame. This is needed when you want to capture dynamic objects. However, it results in an increased render time. Use `godot.ReflectionProbe_UpdateModeEnum.once` whenever possible.
+		Update the probe every frame. This provides better results for fast-moving dynamic objects (such as cars). However, it has a significant performance cost. Due to the cost, it's recommended to only use one ReflectionProbe with `godot.ReflectionProbe_UpdateModeEnum.always` at most per scene. For all other use cases, use `godot.ReflectionProbe_UpdateModeEnum.once`.
 	**/
 	Always;
 }

--- a/godot/Resource.hx
+++ b/godot/Resource.hx
@@ -16,9 +16,6 @@ Note: In C#, resources will not be freed instantly after they are no longer in u
 extern class Resource extends godot.Reference {
 	/**
 		`changed` signal.
-		
-		Emitted whenever the resource changes.
-		`b`Note:`/b` This signal is not emitted automatically for custom resources, which means that you need to create a setter and emit the signal yourself.
 	**/
 	public var onChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onChanged():Signal<Void->Void> {

--- a/godot/RichTextLabel.hx
+++ b/godot/RichTextLabel.hx
@@ -24,8 +24,6 @@ Note: Unicode characters after `0xffff` (such as most emoji) are not supported o
 extern class RichTextLabel extends godot.Control {
 	/**
 		`meta_clicked` signal.
-		
-		Triggered when the user clicks on content between meta tags. If the meta is defined in text, e.g. ``url={"data"="hi"}`hi`/url``, then the parameter for this signal will be a `String` type. If a particular type or an object is desired, the `pushMeta` method must be used to manually insert the data into the tag stack.
 	**/
 	public var onMetaClicked(get, never):Signal<(meta:Any)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMetaClicked():Signal<(meta:Any)->Void> {
@@ -34,8 +32,6 @@ extern class RichTextLabel extends godot.Control {
 
 	/**
 		`meta_hover_ended` signal.
-		
-		Triggers when the mouse exits a meta tag.
 	**/
 	public var onMetaHoverEnded(get, never):Signal<(meta:Any)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMetaHoverEnded():Signal<(meta:Any)->Void> {
@@ -44,8 +40,6 @@ extern class RichTextLabel extends godot.Control {
 
 	/**
 		`meta_hover_started` signal.
-		
-		Triggers when the mouse enters a meta tag.
 	**/
 	public var onMetaHoverStarted(get, never):Signal<(meta:Any)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMetaHoverStarted():Signal<(meta:Any)->Void> {
@@ -131,7 +125,7 @@ extern class RichTextLabel extends godot.Control {
 	/**		
 		The label's text in BBCode format. Is not representative of manual modifications to the internal tag stack. Erases changes made by other methods when edited.
 		
-		Note: It is unadvised to use the `+=` operator with `bbcode_text` (e.g. `bbcode_text += "some string"`) as it replaces the whole text and can cause slowdowns. Use `godot.RichTextLabel.appendBbcode` for adding text instead, unless you absolutely need to close a tag that was opened in an earlier method call.
+		Note: It is unadvised to use the `+=` operator with `bbcode_text` (e.g. `bbcode_text += "some string"`) as it replaces the whole text and can cause slowdowns. It will also erase all BBCode that was added to stack using `push_*` methods. Use `godot.RichTextLabel.appendBbcode` for adding text instead, unless you absolutely need to close a tag that was opened in an earlier method call.
 	**/
 	@:native("BbcodeText")
 	public var bbcodeText:std.String;

--- a/godot/RigidBody.hx
+++ b/godot/RigidBody.hx
@@ -22,9 +22,6 @@ With Bullet physics (the default), the center of mass is the RigidBody3D center.
 extern class RigidBody extends godot.PhysicsBody {
 	/**
 		`body_entered` signal.
-		
-		Emitted when a collision with another `PhysicsBody` or `GridMap` occurs. Requires `contactMonitor` to be set to `true` and `contactsReported` to be set high enough to detect all the collisions. `GridMap`s are detected if the `MeshLibrary` has Collision `Shape`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody` or `GridMap`.
 	**/
 	public var onBodyEntered(get, never):Signal<(body:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyEntered():Signal<(body:Node)->Void> {
@@ -33,9 +30,6 @@ extern class RigidBody extends godot.PhysicsBody {
 
 	/**
 		`body_exited` signal.
-		
-		Emitted when the collision with another `PhysicsBody` or `GridMap` ends. Requires `contactMonitor` to be set to `true` and `contactsReported` to be set high enough to detect all the collisions. `GridMap`s are detected if the `MeshLibrary` has Collision `Shape`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody` or `GridMap`.
 	**/
 	public var onBodyExited(get, never):Signal<(body:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyExited():Signal<(body:Node)->Void> {
@@ -44,13 +38,6 @@ extern class RigidBody extends godot.PhysicsBody {
 
 	/**
 		`body_shape_entered` signal.
-		
-		Emitted when one of this RigidBody's `Shape`s collides with another `PhysicsBody` or `GridMap`'s `Shape`s. Requires `contactMonitor` to be set to `true` and `contactsReported` to be set high enough to detect all the collisions. `GridMap`s are detected if the `MeshLibrary` has Collision `Shape`s.
-		`body_rid` the `RID` of the other `PhysicsBody` or `MeshLibrary`'s `CollisionObject` used by the `PhysicsServer`.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody` or `GridMap`.
-		`body_shape_index` the index of the `Shape` of the other `PhysicsBody` or `GridMap` used by the `PhysicsServer`. Get the `CollisionShape` node with `body.shape_owner_get_owner(body_shape_index)`.
-		`local_shape_index` the index of the `Shape` of this RigidBody used by the `PhysicsServer`. Get the `CollisionShape` node with `self.shape_owner_get_owner(local_shape_index)`.
-		`b`Note:`/b` Bullet physics cannot identify the shape index when using a `ConcavePolygonShape`. Don't use multiple `CollisionShape`s when using a `ConcavePolygonShape` with Bullet physics if you need shape indices.
 	**/
 	public var onBodyShapeEntered(get, never):Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyShapeEntered():Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -59,13 +46,6 @@ extern class RigidBody extends godot.PhysicsBody {
 
 	/**
 		`body_shape_exited` signal.
-		
-		Emitted when the collision between one of this RigidBody's `Shape`s and another `PhysicsBody` or `GridMap`'s `Shape`s ends. Requires `contactMonitor` to be set to `true` and `contactsReported` to be set high enough to detect all the collisions. `GridMap`s are detected if the `MeshLibrary` has Collision `Shape`s.
-		`body_rid` the `RID` of the other `PhysicsBody` or `MeshLibrary`'s `CollisionObject` used by the `PhysicsServer`. `GridMap`s are detected if the Meshes have `Shape`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody` or `GridMap`.
-		`body_shape_index` the index of the `Shape` of the other `PhysicsBody` or `GridMap` used by the `PhysicsServer`. Get the `CollisionShape` node with `body.shape_owner_get_owner(body_shape_index)`.
-		`local_shape_index` the index of the `Shape` of this RigidBody used by the `PhysicsServer`. Get the `CollisionShape` node with `self.shape_owner_get_owner(local_shape_index)`.
-		`b`Note:`/b` Bullet physics cannot identify the shape index when using a `ConcavePolygonShape`. Don't use multiple `CollisionShape`s when using a `ConcavePolygonShape` with Bullet physics if you need shape indices.
 	**/
 	public var onBodyShapeExited(get, never):Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyShapeExited():Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -74,9 +54,6 @@ extern class RigidBody extends godot.PhysicsBody {
 
 	/**
 		`sleeping_state_changed` signal.
-		
-		Emitted when the physics engine changes the body's sleeping state.
-		`b`Note:`/b` Changing the value `sleeping` will not trigger this signal. It is only emitted if the sleeping state is changed by the physics engine or `emit_signal("sleeping_state_changed")` is used.
 	**/
 	public var onSleepingStateChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSleepingStateChanged():Signal<Void->Void> {
@@ -84,7 +61,7 @@ extern class RigidBody extends godot.PhysicsBody {
 	}
 
 	/**		
-		Damps RigidBody's rotational forces.
+		Damps RigidBody's rotational forces. If this value is different from -1.0 it will be added to any linear damp derived from the world or areas.
 		
 		See  for more details about damping.
 	**/
@@ -92,13 +69,13 @@ extern class RigidBody extends godot.PhysicsBody {
 	public var angularDamp:Single;
 
 	/**		
-		RigidBody's rotational velocity.
+		The body's rotational velocity in axis-angle format. The magnitude of the vector is the rotation rate in radians per second.
 	**/
 	@:native("AngularVelocity")
 	public var angularVelocity:godot.Vector3;
 
 	/**		
-		The body's linear damp. Cannot be less than -1.0. If this value is different from -1.0, any linear damp derived from the world or areas will be overridden.
+		The body's linear damp. Cannot be less than -1.0. If this value is different from -1.0 it will be added to any linear damp derived from the world or areas.
 		
 		See  for more details about damping.
 	**/
@@ -106,7 +83,7 @@ extern class RigidBody extends godot.PhysicsBody {
 	public var linearDamp:Single;
 
 	/**		
-		The body's linear velocity. Can be used sporadically, but don't set this every frame, because physics may run in another thread and runs at a different granularity. Use `godot.RigidBody._IntegrateForces` as your process loop for precise control of the body state.
+		The body's linear velocity in units per second. Can be used sporadically, but don't set this every frame, because physics may run in another thread and runs at a different granularity. Use `godot.RigidBody._IntegrateForces` as your process loop for precise control of the body state.
 	**/
 	@:native("LinearVelocity")
 	public var linearVelocity:godot.Vector3;

--- a/godot/RigidBody2D.hx
+++ b/godot/RigidBody2D.hx
@@ -24,9 +24,6 @@ The center of mass is always located at the node's origin without taking into ac
 extern class RigidBody2D extends godot.PhysicsBody2D {
 	/**
 		`body_entered` signal.
-		
-		Emitted when a collision with another `PhysicsBody2D` or `TileMap` occurs. Requires `contactMonitor` to be set to `true` and `contactsReported` to be set high enough to detect all the collisions. `TileMap`s are detected if the `TileSet` has Collision `Shape2D`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody2D` or `TileMap`.
 	**/
 	public var onBodyEntered(get, never):Signal<(body:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyEntered():Signal<(body:Node)->Void> {
@@ -35,9 +32,6 @@ extern class RigidBody2D extends godot.PhysicsBody2D {
 
 	/**
 		`body_exited` signal.
-		
-		Emitted when the collision with another `PhysicsBody2D` or `TileMap` ends. Requires `contactMonitor` to be set to `true` and `contactsReported` to be set high enough to detect all the collisions. `TileMap`s are detected if the `TileSet` has Collision `Shape2D`s.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody2D` or `TileMap`.
 	**/
 	public var onBodyExited(get, never):Signal<(body:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyExited():Signal<(body:Node)->Void> {
@@ -46,12 +40,6 @@ extern class RigidBody2D extends godot.PhysicsBody2D {
 
 	/**
 		`body_shape_entered` signal.
-		
-		Emitted when one of this RigidBody2D's `Shape2D`s collides with another `PhysicsBody2D` or `TileMap`'s `Shape2D`s. Requires `contactMonitor` to be set to `true` and `contactsReported` to be set high enough to detect all the collisions. `TileMap`s are detected if the `TileSet` has Collision `Shape2D`s.
-		`body_rid` the `RID` of the other `PhysicsBody2D` or `TileSet`'s `CollisionObject2D` used by the `Physics2DServer`.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody2D` or `TileMap`.
-		`body_shape_index` the index of the `Shape2D` of the other `PhysicsBody2D` or `TileMap` used by the `Physics2DServer`. Get the `CollisionShape2D` node with `body.shape_owner_get_owner(body_shape_index)`.
-		`local_shape_index` the index of the `Shape2D` of this RigidBody2D used by the `Physics2DServer`. Get the `CollisionShape2D` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onBodyShapeEntered(get, never):Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyShapeEntered():Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -60,12 +48,6 @@ extern class RigidBody2D extends godot.PhysicsBody2D {
 
 	/**
 		`body_shape_exited` signal.
-		
-		Emitted when the collision between one of this RigidBody2D's `Shape2D`s and another `PhysicsBody2D` or `TileMap`'s `Shape2D`s ends. Requires `contactMonitor` to be set to `true` and `contactsReported` to be set high enough to detect all the collisions. `TileMap`s are detected if the `TileSet` has Collision `Shape2D`s.
-		`body_rid` the `RID` of the other `PhysicsBody2D` or `TileSet`'s `CollisionObject2D` used by the `Physics2DServer`.
-		`body` the `Node`, if it exists in the tree, of the other `PhysicsBody2D` or `TileMap`.
-		`body_shape_index` the index of the `Shape2D` of the other `PhysicsBody2D` or `TileMap` used by the `Physics2DServer`. Get the `CollisionShape2D` node with `body.shape_owner_get_owner(body_shape_index)`.
-		`local_shape_index` the index of the `Shape2D` of this RigidBody2D used by the `Physics2DServer`. Get the `CollisionShape2D` node with `self.shape_owner_get_owner(local_shape_index)`.
 	**/
 	public var onBodyShapeExited(get, never):Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBodyShapeExited():Signal<(bodyRid:RID, body:Node, bodyShapeIndex:Int, localShapeIndex:Int)->Void> {
@@ -74,9 +56,6 @@ extern class RigidBody2D extends godot.PhysicsBody2D {
 
 	/**
 		`sleeping_state_changed` signal.
-		
-		Emitted when the physics engine changes the body's sleeping state.
-		`b`Note:`/b` Changing the value `sleeping` will not trigger this signal. It is only emitted if the sleeping state is changed by the physics engine or `emit_signal("sleeping_state_changed")` is used.
 	**/
 	public var onSleepingStateChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSleepingStateChanged():Signal<Void->Void> {
@@ -96,7 +75,7 @@ extern class RigidBody2D extends godot.PhysicsBody2D {
 	public var appliedForce:godot.Vector2;
 
 	/**		
-		Damps the body's `godot.RigidBody2D.angularVelocity`. If `-1`, the body will use the Default Angular Damp defined in Project &gt; Project Settings &gt; Physics &gt; 2d.
+		Damps the body's `godot.RigidBody2D.angularVelocity`. If `-1`, the body will use the Default Angular Damp defined in Project &gt; Project Settings &gt; Physics &gt; 2d. If greater than `-1` it will be added to the default project value.
 		
 		See  for more details about damping.
 	**/
@@ -104,13 +83,13 @@ extern class RigidBody2D extends godot.PhysicsBody2D {
 	public var angularDamp:Single;
 
 	/**		
-		The body's rotational velocity.
+		The body's rotational velocity in radians per second.
 	**/
 	@:native("AngularVelocity")
 	public var angularVelocity:Single;
 
 	/**		
-		Damps the body's `godot.RigidBody2D.linearVelocity`. If `-1`, the body will use the Default Linear Damp in Project &gt; Project Settings &gt; Physics &gt; 2d.
+		Damps the body's `godot.RigidBody2D.linearVelocity`. If `-1`, the body will use the Default Linear Damp in Project &gt; Project Settings &gt; Physics &gt; 2d. If greater than `-1` it will be added to the default project value.
 		
 		See  for more details about damping.
 	**/
@@ -118,7 +97,7 @@ extern class RigidBody2D extends godot.PhysicsBody2D {
 	public var linearDamp:Single;
 
 	/**		
-		The body's linear velocity.
+		The body's linear velocity in pixels per second. Can be used sporadically, but don't set this every frame, because physics may run in another thread and runs at a different granularity. Use `godot.RigidBody2D._IntegrateForces` as your process loop for precise control of the body state.
 	**/
 	@:native("LinearVelocity")
 	public var linearVelocity:godot.Vector2;

--- a/godot/RoomManager.hx
+++ b/godot/RoomManager.hx
@@ -13,6 +13,16 @@ In order to utilize the portal occlusion culling system, you must build your lev
 @:autoBuild(godot.Godot.buildUserClass())
 extern class RoomManager extends godot.Spatial {
 	/**		
+		In order to reduce processing for roaming objects, an expansion is applied to their AABB as they move. This expanded volume is used to calculate which rooms the roaming object is within. If the object's exact AABB is still within this expanded volume on the next move, there is no need to reprocess the object, which can save considerable CPU.
+		
+		The downside is that if the expansion is too much, the object may end up unexpectedly sprawling into neighbouring rooms and showing up where it might otherwise be culled.
+		
+		In order to balance roaming performance against culling accuracy, this expansion margin can be customized by the user. It will typically depend on your room and object sizes, and movement speeds. The default value should work reasonably in most circumstances.
+	**/
+	@:native("RoamingExpansionMargin")
+	public var roamingExpansionMargin:Single;
+
+	/**		
 		Usually we don't want objects that only just cross a boundary into an adjacent `godot.Room` to sprawl into that room. To prevent this, each `godot.Portal` has an extra margin, or tolerance zone where objects can enter without sprawling to a neighbouring room.
 		
 		In most cases you can set this here for all portals. It is possible to override the margin for each portal.
@@ -240,4 +250,10 @@ extern class RoomManager extends godot.Spatial {
 
 	@:native("GetDefaultPortalMargin")
 	public function getDefaultPortalMargin():Single;
+
+	@:native("SetRoamingExpansionMargin")
+	public function setRoamingExpansionMargin(roamingExpansionMargin:Single):Void;
+
+	@:native("GetRoamingExpansionMargin")
+	public function getRoamingExpansionMargin():Single;
 }

--- a/godot/SceneTree.hx
+++ b/godot/SceneTree.hx
@@ -18,8 +18,6 @@ You can also use the `godot.SceneTree` to organize your nodes into groups: every
 extern class SceneTree extends godot.MainLoop {
 	/**
 		`connected_to_server` signal.
-		
-		Emitted whenever this `SceneTree`'s `networkPeer` successfully connected to a server. Only emitted on clients.
 	**/
 	public var onConnectedToServer(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectedToServer():Signal<Void->Void> {
@@ -28,8 +26,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`connection_failed` signal.
-		
-		Emitted whenever this `SceneTree`'s `networkPeer` fails to establish a connection to a server. Only emitted on clients.
 	**/
 	public var onConnectionFailed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onConnectionFailed():Signal<Void->Void> {
@@ -38,8 +34,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`files_dropped` signal.
-		
-		Emitted when files are dragged from the OS file manager and dropped in the game window. The arguments are a list of file paths and the identifier of the screen where the drag originated.
 	**/
 	public var onFilesDropped(get, never):Signal<(files:std.Array<std.String>, screen:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFilesDropped():Signal<(files:std.Array<std.String>, screen:Int)->Void> {
@@ -48,8 +42,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`global_menu_action` signal.
-		
-		Emitted whenever global menu item is clicked.
 	**/
 	public var onGlobalMenuAction(get, never):Signal<(id:Any, meta:Any)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onGlobalMenuAction():Signal<(id:Any, meta:Any)->Void> {
@@ -58,8 +50,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`idle_frame` signal.
-		
-		Emitted immediately before `node.Process` is called on every node in the `SceneTree`.
 	**/
 	public var onIdleFrame(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onIdleFrame():Signal<Void->Void> {
@@ -68,8 +58,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`network_peer_connected` signal.
-		
-		Emitted whenever this `SceneTree`'s `networkPeer` connects with a new peer. ID is the peer ID of the new peer. Clients get notified when other clients connect to the same server. Upon connecting to a server, a client also receives this signal for the server (with ID being 1).
 	**/
 	public var onNetworkPeerConnected(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNetworkPeerConnected():Signal<(id:Int)->Void> {
@@ -78,8 +66,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`network_peer_disconnected` signal.
-		
-		Emitted whenever this `SceneTree`'s `networkPeer` disconnects from a peer. Clients get notified when other clients disconnect from the same server.
 	**/
 	public var onNetworkPeerDisconnected(get, never):Signal<(id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNetworkPeerDisconnected():Signal<(id:Int)->Void> {
@@ -88,8 +74,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`node_added` signal.
-		
-		Emitted whenever a node is added to the `SceneTree`.
 	**/
 	public var onNodeAdded(get, never):Signal<(node:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNodeAdded():Signal<(node:Node)->Void> {
@@ -98,8 +82,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`node_configuration_warning_changed` signal.
-		
-		Emitted when a node's configuration changed. Only emitted in `tool` mode.
 	**/
 	public var onNodeConfigurationWarningChanged(get, never):Signal<(node:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNodeConfigurationWarningChanged():Signal<(node:Node)->Void> {
@@ -108,8 +90,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`node_removed` signal.
-		
-		Emitted whenever a node is removed from the `SceneTree`.
 	**/
 	public var onNodeRemoved(get, never):Signal<(node:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNodeRemoved():Signal<(node:Node)->Void> {
@@ -118,8 +98,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`node_renamed` signal.
-		
-		Emitted whenever a node is renamed.
 	**/
 	public var onNodeRenamed(get, never):Signal<(node:Node)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNodeRenamed():Signal<(node:Node)->Void> {
@@ -128,8 +106,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`physics_frame` signal.
-		
-		Emitted immediately before `node.PhysicsProcess` is called on every node in the `SceneTree`.
 	**/
 	public var onPhysicsFrame(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPhysicsFrame():Signal<Void->Void> {
@@ -138,8 +114,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`screen_resized` signal.
-		
-		Emitted when the screen resolution (fullscreen) or window size (windowed) changes.
 	**/
 	public var onScreenResized(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScreenResized():Signal<Void->Void> {
@@ -148,8 +122,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`server_disconnected` signal.
-		
-		Emitted whenever this `SceneTree`'s `networkPeer` disconnected from server. Only emitted on clients.
 	**/
 	public var onServerDisconnected(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onServerDisconnected():Signal<Void->Void> {
@@ -158,8 +130,6 @@ extern class SceneTree extends godot.MainLoop {
 
 	/**
 		`tree_changed` signal.
-		
-		Emitted whenever the `SceneTree` hierarchy changed (children being moved or renamed, etc.).
 	**/
 	public var onTreeChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTreeChanged():Signal<Void->Void> {
@@ -205,7 +175,11 @@ extern class SceneTree extends godot.MainLoop {
 	public var editedSceneRoot:godot.Node;
 
 	/**		
-		If `true`, font oversampling is used.
+		If `true`, font oversampling is enabled. This means that `godot.DynamicFont`s will be rendered at higher or lower size than configured based on the viewport's scaling ratio. For example, in a viewport scaled with a factor 1.5, a font configured with size 14 would be rendered with size 21 (`14 * 1.5`).
+		
+		Note: Font oversampling is only used if the viewport stretch mode is `godot.SceneTree_StretchMode.viewport`, and if the stretch aspect mode is different from `godot.SceneTree_StretchAspect.ignore`.
+		
+		Note: This property is set automatically for the active `godot.SceneTree` when the project starts based on the configuration of `rendering/quality/dynamic_fonts/use_oversampling` in `godot.ProjectSettings`. The property can however be overridden at runtime as needed.
 	**/
 	@:native("UseFontOversampling")
 	public var useFontOversampling:Bool;
@@ -506,6 +480,8 @@ extern class SceneTree extends godot.MainLoop {
 		Returns `OK` on success or `ERR_CANT_CREATE` if the scene cannot be instantiated.
 		
 		Note: The scene change is deferred, which means that the new scene node is added on the next idle frame. You won't be able to access it immediately after the `godot.SceneTree.changeSceneTo` call.
+		
+		Note: Passing a value of `null` into the method will unload the current scene without loading a new one.
 	**/
 	@:native("ChangeSceneTo")
 	public function changeSceneTo(packedScene:godot.PackedScene):godot.Error;

--- a/godot/SceneTreeTimer.hx
+++ b/godot/SceneTreeTimer.hx
@@ -17,6 +17,8 @@ yield(get_tree().create_timer(1.0), "timeout")
 print("Timer ended.")
 
 ```
+
+The timer will be automatically freed after its time elapses.
 **/
 @:libType
 @:csNative
@@ -25,8 +27,6 @@ print("Timer ended.")
 extern abstract class SceneTreeTimer extends godot.Reference {
 	/**
 		`timeout` signal.
-		
-		Emitted when the timer reaches 0.
 	**/
 	public var onTimeout(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTimeout():Signal<Void->Void> {
@@ -34,7 +34,7 @@ extern abstract class SceneTreeTimer extends godot.Reference {
 	}
 
 	/**		
-		The time remaining.
+		The time remaining (in seconds).
 	**/
 	@:native("TimeLeft")
 	public var timeLeft:Single;

--- a/godot/ScriptCreateDialog.hx
+++ b/godot/ScriptCreateDialog.hx
@@ -23,8 +23,6 @@ dialog.popup_centered()
 extern class ScriptCreateDialog extends godot.ConfirmationDialog {
 	/**
 		`script_created` signal.
-		
-		Emitted when the user clicks the OK button.
 	**/
 	public var onScriptCreated(get, never):Signal<(script:Script)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScriptCreated():Signal<(script:Script)->Void> {

--- a/godot/ScriptEditor.hx
+++ b/godot/ScriptEditor.hx
@@ -14,8 +14,6 @@ Note: This class shouldn't be instantiated directly. Instead, access the singlet
 extern abstract class ScriptEditor extends godot.PanelContainer {
 	/**
 		`editor_script_changed` signal.
-		
-		Emitted when user changed active script. Argument is a freshly activated `Script`.
 	**/
 	public var onEditorScriptChanged(get, never):Signal<(script:Script)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onEditorScriptChanged():Signal<(script:Script)->Void> {
@@ -24,8 +22,6 @@ extern abstract class ScriptEditor extends godot.PanelContainer {
 
 	/**
 		`script_close` signal.
-		
-		Emitted when editor is about to close the active script. Argument is a `Script` that is going to be closed.
 	**/
 	public var onScriptClose(get, never):Signal<(script:Script)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScriptClose():Signal<(script:Script)->Void> {

--- a/godot/ScrollBar.hx
+++ b/godot/ScrollBar.hx
@@ -14,8 +14,6 @@ Scrollbars are a `godot.Range`-based `godot.Control`, that display a draggable a
 extern abstract class ScrollBar extends godot.Range {
 	/**
 		`scrolling` signal.
-		
-		Emitted when the scrollbar is being scrolled.
 	**/
 	public var onScrolling(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScrolling():Signal<Void->Void> {

--- a/godot/ScrollContainer.hx
+++ b/godot/ScrollContainer.hx
@@ -14,8 +14,6 @@ A ScrollContainer node meant to contain a `godot.Control` child. ScrollContainer
 extern class ScrollContainer extends godot.Container {
 	/**
 		`scroll_ended` signal.
-		
-		Emitted when scrolling stops.
 	**/
 	public var onScrollEnded(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScrollEnded():Signal<Void->Void> {
@@ -24,8 +22,6 @@ extern class ScrollContainer extends godot.Container {
 
 	/**
 		`scroll_started` signal.
-		
-		Emitted when scrolling is started.
 	**/
 	public var onScrollStarted(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScrollStarted():Signal<Void->Void> {
@@ -122,6 +118,16 @@ extern class ScrollContainer extends godot.Container {
 
 	/**		
 		Ensures the given `control` is visible (must be a direct or indirect child of the ScrollContainer). Used by `godot.ScrollContainer.followFocus`.
+		
+		Note: This will not work on a node that was just added during the same frame. If you want to scroll to a newly added child, you must wait until the next frame using `SceneTree.idle_frame`:
+		
+		```
+		
+		add_child(child_node)
+		yield(get_tree(), "idle_frame")
+		ensure_control_visible(child_node)
+		
+		```
 	**/
 	@:native("EnsureControlVisible")
 	public function ensureControlVisible(control:godot.Control):Void;

--- a/godot/Shape2D.hx
+++ b/godot/Shape2D.hx
@@ -41,7 +41,11 @@ extern abstract class Shape2D extends godot.Resource {
 	public function collideWithMotion(localXform:godot.Transform2D, localMotion:godot.Vector2, withShape:godot.Shape2D, shapeXform:godot.Transform2D, shapeMotion:godot.Vector2):Bool;
 
 	/**		
-		Returns a list of the points where this shape touches another. If there are no collisions the list is empty.
+		Returns a list of contact point pairs where this shape touches another.
+		
+		If there are no collisions, the returned list is empty. Otherwise, the returned list contains contact points arranged in pairs, with entries alternating between points on the boundary of this shape and points on the boundary of `with_shape`.
+		
+		A collision pair A, B can be used to calculate the collision normal with `(B - A).normalized()`, and the collision depth with `(B - A).length()`. This information is typically used to separate shapes, particularly in collision solvers.
 		
 		This method needs the transformation matrix for this shape (`local_xform`), the shape to check collisions with (`with_shape`), and the transformation matrix of that shape (`shape_xform`).
 	**/
@@ -49,7 +53,11 @@ extern abstract class Shape2D extends godot.Resource {
 	public function collideAndGetContacts(localXform:godot.Transform2D, withShape:godot.Shape2D, shapeXform:godot.Transform2D):godot.collections.Array;
 
 	/**		
-		Returns a list of the points where this shape would touch another, if a given movement was applied. If there are no collisions the list is empty.
+		Returns a list of contact point pairs where this shape would touch another, if a given movement was applied.
+		
+		If there would be no collisions, the returned list is empty. Otherwise, the returned list contains contact points arranged in pairs, with entries alternating between points on the boundary of this shape and points on the boundary of `with_shape`.
+		
+		A collision pair A, B can be used to calculate the collision normal with `(B - A).normalized()`, and the collision depth with `(B - A).length()`. This information is typically used to separate shapes, particularly in collision solvers.
 		
 		This method needs the transformation matrix for this shape (`local_xform`), the movement to test on this shape (`local_motion`), the shape to check collisions with (`with_shape`), the transformation matrix of that shape (`shape_xform`), and the movement to test onto the other object (`shape_motion`).
 	**/

--- a/godot/SoftBody.hx
+++ b/godot/SoftBody.hx
@@ -6,6 +6,8 @@ import cs.system.*;
 
 /**
 A deformable physics body. Used to create elastic or deformable objects such as cloth, rubber, or other flexible materials.
+
+Note: There are many known bugs in `godot.SoftBody`. Therefore, it's not recommended to use them for things that can affect gameplay (such as a player character made entirely out of soft bodies).
 **/
 @:libType
 @:csNative

--- a/godot/Spatial.hx
+++ b/godot/Spatial.hx
@@ -18,8 +18,6 @@ Note: Unless otherwise specified, all methods that have angle parameters must ha
 extern class Spatial extends godot.Node {
 	/**
 		`gameplay_entered` signal.
-		
-		Emitted by portal system gameplay monitor when a node enters the gameplay area.
 	**/
 	public var onGameplayEntered(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onGameplayEntered():Signal<Void->Void> {
@@ -28,8 +26,6 @@ extern class Spatial extends godot.Node {
 
 	/**
 		`gameplay_exited` signal.
-		
-		Emitted by portal system gameplay monitor when a node exits the gameplay area.
 	**/
 	public var onGameplayExited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onGameplayExited():Signal<Void->Void> {
@@ -38,8 +34,6 @@ extern class Spatial extends godot.Node {
 
 	/**
 		`visibility_changed` signal.
-		
-		Emitted when node visibility changes.
 	**/
 	public var onVisibilityChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onVisibilityChanged():Signal<Void->Void> {
@@ -362,9 +356,11 @@ extern class Spatial extends godot.Node {
 	public function setIdentity():Void;
 
 	/**		
-		Rotates itself so that the local -Z axis points towards the `target` position.
+		Rotates the node so that the local forward axis (-Z) points toward the `target` position.
 		
-		The transform will first be rotated around the given `up` vector, and then fully aligned to the target by a further rotation around an axis perpendicular to both the `target` and `up` vectors.
+		The local up axis (+Y) points as close to the `up` vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
+		
+		The `target` position cannot be the same as the node's position, the `up` vector cannot be zero, and the direction from the node's position to the `target` vector cannot be parallel to the `up` vector.
 		
 		Operations take place in global space.
 	**/

--- a/godot/SpatialMaterial.hx
+++ b/godot/SpatialMaterial.hx
@@ -97,7 +97,7 @@ extern class SpatialMaterial extends godot.Material {
 	/**		
 		Texture that specifies the per-pixel normal of the detail overlay.
 		
-		Note: Godot expects the normal map to use X+, Y-, and Z+ coordinates. See [http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates](this page) for a comparison of normal map coordinates expected by popular engines.
+		Note: Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates](this page) for a comparison of normal map coordinates expected by popular engines.
 	**/
 	@:native("DetailNormal")
 	public var detailNormal:godot.Texture;
@@ -273,19 +273,25 @@ extern class SpatialMaterial extends godot.Material {
 	public var aoEnabled:Bool;
 
 	/**		
-		Texture that offsets the tangent map for anisotropy calculations.
+		Texture that offsets the tangent map for anisotropy calculations and optionally controls the anisotropy effect (if an alpha channel is present). The flowmap texture is expected to be a derivative map, with the red channel representing distortion on the X axis and green channel representing distortion on the Y axis. Values below 0.5 will result in negative distortion, whereas values above 0.5 will result in positive distortion.
+		
+		If present, the texture's alpha channel will be used to multiply the strength of the `godot.SpatialMaterial.anisotropy` effect. Fully opaque pixels will keep the anisotropy effect's original strength while fully transparent pixels will disable the anisotropy effect entirely. The flowmap texture's blue channel is ignored.
 	**/
 	@:native("AnisotropyFlowmap")
 	public var anisotropyFlowmap:godot.Texture;
 
 	/**		
-		The strength of the anisotropy effect.
+		The strength of the anisotropy effect. This is multiplied by `godot.SpatialMaterial.anisotropyFlowmap`'s alpha channel if a texture is defined there and the texture contains an alpha channel.
 	**/
 	@:native("Anisotropy")
 	public var anisotropy:Single;
 
 	/**		
-		If `true`, anisotropy is enabled. Changes the shape of the specular blob and aligns it to tangent space. Mesh tangents are needed for this to work. If the mesh does not contain tangents the anisotropy effect will appear broken.
+		If `true`, anisotropy is enabled. Anisotropy changes the shape of the specular blob and aligns it to tangent space. This is useful for brushed aluminium and hair reflections.
+		
+		Note: Mesh tangents are needed for anisotropy to work. If the mesh does not contain tangents, the anisotropy effect will appear broken.
+		
+		Note: Material anisotropy should not to be confused with anisotropic texture filtering. Anisotropic texture filtering can be enabled by selecting a texture in the FileSystem dock, going to the Import dock, checking the Anisotropic checkbox then clicking Reimport.
 	**/
 	@:native("AnisotropyEnabled")
 	public var anisotropyEnabled:Bool;
@@ -347,7 +353,7 @@ extern class SpatialMaterial extends godot.Material {
 		
 		Note: The mesh must have both normals and tangents defined in its vertex data. Otherwise, the normal map won't render correctly and will only appear to darken the whole surface. If creating geometry with `godot.SurfaceTool`, you can use `godot.SurfaceTool.generateNormals` and `godot.SurfaceTool.generateTangents` to automatically generate normals and tangents respectively.
 		
-		Note: Godot expects the normal map to use X+, Y-, and Z+ coordinates. See [http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates](this page) for a comparison of normal map coordinates expected by popular engines.
+		Note: Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates](this page) for a comparison of normal map coordinates expected by popular engines.
 	**/
 	@:native("NormalTexture")
 	public var normalTexture:godot.Texture;
@@ -619,7 +625,13 @@ extern class SpatialMaterial extends godot.Material {
 	public var flagsNoDepthTest:Bool;
 
 	/**		
-		If `true`, lighting is calculated per vertex rather than per pixel. This may increase performance on low-end devices.
+		If `true`, lighting is calculated per vertex rather than per pixel. This may increase performance on low-end devices, especially for meshes with a lower polygon count. The downside is that shading becomes much less accurate, with visible linear interpolation between vertices that are joined together. This can be compensated by ensuring meshes have a sufficient level of subdivision (but not too much, to avoid reducing performance). Some material features are also not supported when vertex shading is enabled.
+		
+		See also  which can globally enable vertex shading on all materials.
+		
+		Note: By default, vertex shading is enforced on mobile platforms by 's `mobile` override.
+		
+		Note: `godot.SpatialMaterial.flagsVertexLighting` has no effect if `godot.SpatialMaterial.flagsUnshaded` is `true`.
 	**/
 	@:native("FlagsVertexLighting")
 	public var flagsVertexLighting:Bool;

--- a/godot/SplitContainer.hx
+++ b/godot/SplitContainer.hx
@@ -14,8 +14,6 @@ Container for splitting two `godot.Control`s vertically or horizontally, with a 
 extern abstract class SplitContainer extends godot.Container {
 	/**
 		`dragged` signal.
-		
-		Emitted when the dragger is dragged by user.
 	**/
 	public var onDragged(get, never):Signal<(offset:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onDragged():Signal<(offset:Int)->Void> {

--- a/godot/Sprite.hx
+++ b/godot/Sprite.hx
@@ -14,8 +14,6 @@ A node that displays a 2D texture. The texture displayed can be a region from a 
 extern class Sprite extends godot.Node2D {
 	/**
 		`frame_changed` signal.
-		
-		Emitted when the `frame` changes.
 	**/
 	public var onFrameChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFrameChanged():Signal<Void->Void> {
@@ -24,8 +22,6 @@ extern class Sprite extends godot.Node2D {
 
 	/**
 		`texture_changed` signal.
-		
-		Emitted when the `texture` changes.
 	**/
 	public var onTextureChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextureChanged():Signal<Void->Void> {

--- a/godot/Sprite3D.hx
+++ b/godot/Sprite3D.hx
@@ -14,8 +14,6 @@ A node that displays a 2D texture in a 3D environment. The texture displayed can
 extern class Sprite3D extends godot.SpriteBase3D {
 	/**
 		`frame_changed` signal.
-		
-		Emitted when the `frame` changes.
 	**/
 	public var onFrameChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFrameChanged():Signal<Void->Void> {

--- a/godot/SpriteBase3D.hx
+++ b/godot/SpriteBase3D.hx
@@ -49,13 +49,17 @@ extern abstract class SpriteBase3D extends godot.GeometryInstance {
 	public var pixelSize:Single;
 
 	/**		
-		The objects' visibility on a scale from `0` fully invisible to `1` fully visible.
+		The texture's visibility on a scale from `0` (fully invisible) to `1` (fully visible). `godot.SpriteBase3D.opacity` is a multiplier for the `godot.SpriteBase3D.modulate` color's alpha channel.
+		
+		Note: If a `godot.GeometryInstance.materialOverride` is defined on the `godot.SpriteBase3D`, the material override must be configured to take vertex colors into account for albedo. Otherwise, the opacity defined in `godot.SpriteBase3D.opacity` will be ignored. For a `godot.SpatialMaterial`, `godot.SpatialMaterial.vertexColorUseAsAlbedo` must be `true`. For a `godot.ShaderMaterial`, `ALPHA *= COLOR.a;[/color] must be inserted in the shader's [code]fragment()` function.
 	**/
 	@:native("Opacity")
 	public var opacity:Single;
 
 	/**		
-		A color value that gets multiplied on, could be used for mood-coloring or to simulate the color of light.
+		A color value used to multiply the texture's colors. Can be used for mood-coloring or to simulate the color of light.
+		
+		Note: If a `godot.GeometryInstance.materialOverride` is defined on the `godot.SpriteBase3D`, the material override must be configured to take vertex colors into account for albedo. Otherwise, the color defined in `godot.SpriteBase3D.modulate` will be ignored. For a `godot.SpatialMaterial`, `godot.SpatialMaterial.vertexColorUseAsAlbedo` must be `true`. For a `godot.ShaderMaterial`, `ALBEDO *= COLOR.rgb;[/color] must be inserted in the shader's [code]fragment()` function.
 	**/
 	@:native("Modulate")
 	public var modulate:godot.Color;

--- a/godot/SpriteFrames.hx
+++ b/godot/SpriteFrames.hx
@@ -5,7 +5,7 @@ package godot;
 import cs.system.*;
 
 /**
-Sprite frame library for `godot.AnimatedSprite`. Contains frames and animation data for playback.
+Sprite frame library for an `godot.AnimatedSprite` or `godot.AnimatedSprite3D` node. Contains frames and animation data for playback.
 
 Note: You can associate a set of normal maps by creating additional `godot.SpriteFrames` resources with a `_normal` suffix. For example, having 2 `godot.SpriteFrames` resources `run` and `run_normal` will make it so the `run` animation uses the normal map.
 **/

--- a/godot/StreamPeer.hx
+++ b/godot/StreamPeer.hx
@@ -224,19 +224,19 @@ extern abstract class StreamPeer extends godot.Reference {
 
 	#if doc_gen
 	/**		
-		Gets a string with byte-length `bytes` from the stream. If `bytes` is negative (default) the length will be read from the stream using the reverse process of `godot.StreamPeer.putString`.
+		Gets an ASCII string with byte-length `bytes` from the stream. If `bytes` is negative (default) the length will be read from the stream using the reverse process of `godot.StreamPeer.putString`.
 	**/
 	@:native("GetString")
 	public function getString(?bytes:Int):std.String;
 	#else
 	/**		
-		Gets a string with byte-length `bytes` from the stream. If `bytes` is negative (default) the length will be read from the stream using the reverse process of `godot.StreamPeer.putString`.
+		Gets an ASCII string with byte-length `bytes` from the stream. If `bytes` is negative (default) the length will be read from the stream using the reverse process of `godot.StreamPeer.putString`.
 	**/
 	@:native("GetString")
 	public overload function getString():std.String;
 
 	/**		
-		Gets a string with byte-length `bytes` from the stream. If `bytes` is negative (default) the length will be read from the stream using the reverse process of `godot.StreamPeer.putString`.
+		Gets an ASCII string with byte-length `bytes` from the stream. If `bytes` is negative (default) the length will be read from the stream using the reverse process of `godot.StreamPeer.putString`.
 	**/
 	@:native("GetString")
 	public overload function getString(bytes:Int):std.String;

--- a/godot/StringExtensions.hx
+++ b/godot/StringExtensions.hx
@@ -498,7 +498,7 @@ extern class StringExtensions {
 
 	/**		
 		Returns `true` if the string is a path to a file or
-		directory and its startign point is explicitly defined. This includes
+		directory and its starting point is explicitly defined. This includes
 		`res://`, `user://`, `C:\`, `/`, etc.
 		@see `godot.StringExtensions.isRelPath`
 		@param instance The string to check.

--- a/godot/StyleBoxTexture.hx
+++ b/godot/StyleBoxTexture.hx
@@ -14,8 +14,6 @@ Texture-based nine-patch `godot.StyleBox`, in a way similar to `godot.NinePatchR
 extern class StyleBoxTexture extends godot.StyleBox {
 	/**
 		`texture_changed` signal.
-		
-		Emitted when the stylebox's texture is changed.
 	**/
 	public var onTextureChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextureChanged():Signal<Void->Void> {

--- a/godot/SurfaceTool.hx
+++ b/godot/SurfaceTool.hx
@@ -273,6 +273,8 @@ extern class SurfaceTool extends godot.Reference {
 
 	/**		
 		Append vertices from a given `godot.Mesh` surface onto the current vertex array with specified `godot.Transform`.
+		
+		Note: Using `godot.SurfaceTool.appendFrom` on a `godot.Thread` is much slower as the GPU must communicate data back to the CPU, while also causing the main thread to stall (as OpenGL is not thread-safe). Consider requesting a copy of the mesh, converting it to an `godot.ArrayMesh` and adding vertices manually instead.
 	**/
 	@:native("AppendFrom")
 	public function appendFrom(existing:godot.Mesh, surface:Int, transform:godot.Transform):Void;

--- a/godot/TabContainer.hx
+++ b/godot/TabContainer.hx
@@ -5,9 +5,11 @@ package godot;
 import cs.system.*;
 
 /**
-Sets the active tab's `visible` property to the value `true`. Sets all other children's to `false`.
+Arranges `godot.Control` children into a tabbed view, creating a tab for each one. The active tab's corresponding `godot.Control` has its `visible` property set to `true`, and all other children's to `false`.
 
 Ignores non-`godot.Control` children.
+
+Note: The drawing of the clickable tabs themselves is handled by this node. Adding `godot.Tabs` as children is not needed.
 **/
 @:libType
 @:csNative
@@ -16,8 +18,6 @@ Ignores non-`godot.Control` children.
 extern class TabContainer extends godot.Container {
 	/**
 		`pre_popup_pressed` signal.
-		
-		Emitted when the `TabContainer`'s `Popup` button is clicked. See `setPopup` for details.
 	**/
 	public var onPrePopupPressed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPrePopupPressed():Signal<Void->Void> {
@@ -26,8 +26,6 @@ extern class TabContainer extends godot.Container {
 
 	/**
 		`tab_changed` signal.
-		
-		Emitted when switching to another tab.
 	**/
 	public var onTabChanged(get, never):Signal<(tab:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTabChanged():Signal<(tab:Int)->Void> {
@@ -36,8 +34,6 @@ extern class TabContainer extends godot.Container {
 
 	/**
 		`tab_selected` signal.
-		
-		Emitted when a tab is selected, even if it is the current tab.
 	**/
 	public var onTabSelected(get, never):Signal<(tab:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTabSelected():Signal<(tab:Int)->Void> {

--- a/godot/Tabs.hx
+++ b/godot/Tabs.hx
@@ -14,8 +14,6 @@ Simple tabs control, similar to `godot.TabContainer` but is only in charge of dr
 extern class Tabs extends godot.Control {
 	/**
 		`reposition_active_tab_request` signal.
-		
-		Emitted when the active tab is rearranged via mouse drag. See `dragToRearrangeEnabled`.
 	**/
 	public var onRepositionActiveTabRequest(get, never):Signal<(idxTo:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRepositionActiveTabRequest():Signal<(idxTo:Int)->Void> {
@@ -24,8 +22,6 @@ extern class Tabs extends godot.Control {
 
 	/**
 		`right_button_pressed` signal.
-		
-		Emitted when a tab is right-clicked.
 	**/
 	public var onRightButtonPressed(get, never):Signal<(tab:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onRightButtonPressed():Signal<(tab:Int)->Void> {
@@ -34,8 +30,6 @@ extern class Tabs extends godot.Control {
 
 	/**
 		`tab_changed` signal.
-		
-		Emitted when switching to another tab.
 	**/
 	public var onTabChanged(get, never):Signal<(tab:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTabChanged():Signal<(tab:Int)->Void> {
@@ -44,8 +38,6 @@ extern class Tabs extends godot.Control {
 
 	/**
 		`tab_clicked` signal.
-		
-		Emitted when a tab is clicked, even if it is the current tab.
 	**/
 	public var onTabClicked(get, never):Signal<(tab:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTabClicked():Signal<(tab:Int)->Void> {
@@ -54,8 +46,6 @@ extern class Tabs extends godot.Control {
 
 	/**
 		`tab_close` signal.
-		
-		Emitted when a tab is closed.
 	**/
 	public var onTabClose(get, never):Signal<(tab:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTabClose():Signal<(tab:Int)->Void> {
@@ -64,8 +54,6 @@ extern class Tabs extends godot.Control {
 
 	/**
 		`tab_hover` signal.
-		
-		Emitted when a tab is hovered by the mouse.
 	**/
 	public var onTabHover(get, never):Signal<(tab:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTabHover():Signal<(tab:Int)->Void> {

--- a/godot/TextEdit.hx
+++ b/godot/TextEdit.hx
@@ -16,8 +16,6 @@ Note: When holding down `Alt`, the vertical scroll wheel will scroll 5 times as 
 extern class TextEdit extends godot.Control {
 	/**
 		`breakpoint_toggled` signal.
-		
-		Emitted when a breakpoint is placed via the breakpoint gutter.
 	**/
 	public var onBreakpointToggled(get, never):Signal<(row:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onBreakpointToggled():Signal<(row:Int)->Void> {
@@ -26,8 +24,6 @@ extern class TextEdit extends godot.Control {
 
 	/**
 		`cursor_changed` signal.
-		
-		Emitted when the cursor changes.
 	**/
 	public var onCursorChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCursorChanged():Signal<Void->Void> {
@@ -36,8 +32,6 @@ extern class TextEdit extends godot.Control {
 
 	/**
 		`info_clicked` signal.
-		
-		Emitted when the info icon is clicked.
 	**/
 	public var onInfoClicked(get, never):Signal<(row:Int, info:std.String)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onInfoClicked():Signal<(row:Int, info:std.String)->Void> {
@@ -62,8 +56,6 @@ extern class TextEdit extends godot.Control {
 
 	/**
 		`text_changed` signal.
-		
-		Emitted when the text changes.
 	**/
 	public var onTextChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTextChanged():Signal<Void->Void> {
@@ -197,6 +189,12 @@ extern class TextEdit extends godot.Control {
 	public var breakpointGutter:Bool;
 
 	/**		
+		If `true`, the bookmark gutter is visible.
+	**/
+	@:native("BookmarkGutter")
+	public var bookmarkGutter:Bool;
+
+	/**		
 		If `true`, the "space" character will have a visible representation.
 	**/
 	@:native("DrawSpaces")
@@ -270,6 +268,51 @@ extern class TextEdit extends godot.Control {
 	**/
 	@:native("SetLine")
 	public function setLine(line:Int, newText:std.String):Void;
+
+	/**		
+		Returns an array of `String`s representing each wrapped index.
+	**/
+	public extern inline function getLineWrappedText(line:Int):std.Array<std.String> {
+		return cs.Lib.array(cs.Syntax.code("{0}.GetLineWrappedText({1})", this, line));
+	}
+
+	#if doc_gen
+	/**		
+		Returns the width in pixels of the `wrap_index` on `line`.
+	**/
+	@:native("GetLineWidth")
+	public function getLineWidth(line:Int, ?wrapIndex:Int):Int;
+	#else
+	/**		
+		Returns the width in pixels of the `wrap_index` on `line`.
+	**/
+	@:native("GetLineWidth")
+	public overload function getLineWidth(line:Int):Int;
+
+	/**		
+		Returns the width in pixels of the `wrap_index` on `line`.
+	**/
+	@:native("GetLineWidth")
+	public overload function getLineWidth(line:Int, wrapIndex:Int):Int;
+	#end
+
+	/**		
+		Returns the height of a largest line.
+	**/
+	@:native("GetLineHeight")
+	public function getLineHeight():Int;
+
+	/**		
+		Returns if the given line is wrapped.
+	**/
+	@:native("IsLineWrapped")
+	public function isLineWrapped(line:Int):Bool;
+
+	/**		
+		Returns the number of times the given line is wrapped.
+	**/
+	@:native("GetLineWrapCount")
+	public function getLineWrapCount(line:Int):Int;
 
 	/**		
 		Centers the viewport on the line the editing cursor is at. This also resets the `godot.TextEdit.scrollHorizontal` value to `0`.
@@ -390,6 +433,28 @@ extern class TextEdit extends godot.Control {
 
 	@:native("IsRightClickMovingCaret")
 	public function isRightClickMovingCaret():Bool;
+
+	/**		
+		Returns the local position for the given `line` and `column`. If `x` or `y` of the returned vector equal `-1`, the position is outside of the viewable area of the control.
+		
+		Note: The Y position corresponds to the bottom side of the line. Use `godot.TextEdit.getRectAtLineColumn` to get the top side position.
+	**/
+	@:native("GetPosAtLineColumn")
+	public function getPosAtLineColumn(line:Int, column:Int):godot.Vector2;
+
+	/**		
+		Returns the local position and size for the grapheme at the given `line` and `column`. If `x` or `y` position of the returned rect equal `-1`, the position is outside of the viewable area of the control.
+		
+		Note: The Y position of the returned rect corresponds to the top side of the line, unlike `godot.TextEdit.getPosAtLineColumn` which returns the bottom side.
+	**/
+	@:native("GetRectAtLineColumn")
+	public function getRectAtLineColumn(line:Int, column:Int):godot.Rect2;
+
+	/**		
+		Returns the line and column at the given position. In the returned vector, `x` is the column, `y` is the line.
+	**/
+	@:native("GetLineColumnAtPos")
+	public function getLineColumnAtPos(position:godot.Vector2):godot.Vector2;
 
 	@:native("SetReadonly")
 	public function setReadonly(enable:Bool):Void;
@@ -616,6 +681,12 @@ extern class TextEdit extends godot.Control {
 	@:native("IsDrawingSpaces")
 	public function isDrawingSpaces():Bool;
 
+	@:native("SetBookmarkGutterEnabled")
+	public function setBookmarkGutterEnabled(enable:Bool):Void;
+
+	@:native("IsBookmarkGutterEnabled")
+	public function isBookmarkGutterEnabled():Bool;
+
 	@:native("SetBreakpointGutterEnabled")
 	public function setBreakpointGutterEnabled(enable:Bool):Void;
 
@@ -627,6 +698,12 @@ extern class TextEdit extends godot.Control {
 
 	@:native("IsDrawingFoldGutter")
 	public function isDrawingFoldGutter():Bool;
+
+	/**		
+		Returns the total width of all gutters and internal padding.
+	**/
+	@:native("GetTotalGutterWidth")
+	public function getTotalGutterWidth():Int;
 
 	@:native("SetHidingEnabled")
 	public function setHidingEnabled(enable:Bool):Void;

--- a/godot/Texture3D.hx
+++ b/godot/Texture3D.hx
@@ -5,7 +5,9 @@ package godot;
 import cs.system.*;
 
 /**
-Texture3D is a 3-dimensional texture that has a width, height, and depth.
+Texture3D is a 3-dimensional `godot.Texture` that has a width, height, and depth. See also `godot.TextureArray`.
+
+Note: `godot.Texture3D`s can only be sampled in shaders in the GLES3 backend. In GLES2, their data can be accessed via scripting, but there is no way to render them in a hardware-accelerated manner.
 **/
 @:libType
 @:csNative

--- a/godot/TextureArray.hx
+++ b/godot/TextureArray.hx
@@ -5,9 +5,9 @@ package godot;
 import cs.system.*;
 
 /**
-`godot.TextureArray`s store an array of `godot.Image`s in a single `godot.Texture` primitive. Each layer of the texture array has its own mipmap chain. This makes it is a good alternative to texture atlases.
+`godot.TextureArray`s store an array of `godot.Image`s in a single `godot.Texture` primitive. Each layer of the texture array has its own mipmap chain. This makes it is a good alternative to texture atlases. See also `godot.Texture3D`.
 
-`godot.TextureArray`s must be displayed using shaders. After importing your file as a `godot.TextureArray` and setting the appropriate Horizontal and Vertical Slices, display it by setting it as a uniform to a shader, for example:
+`godot.TextureArray`s must be displayed using shaders. After importing your file as a `godot.TextureArray` and setting the appropriate Horizontal and Vertical Slices, display it by setting it as a uniform to a shader, for example (2D):
 
 ```
 
@@ -23,6 +23,23 @@ COLOR = texture(tex, vec3(UV.x, UV.y, float(index)));
 ```
 
 Set the integer uniform "index" to show a particular part of the texture as defined by the Horizontal and Vertical Slices in the importer.
+
+Note: When sampling an albedo texture from a texture array in 3D, the sRGB -&gt; linear conversion hint (`hint_albedo`) should be used to prevent colors from looking washed out:
+
+```
+
+shader_type spatial;
+
+uniform sampler2DArray tex : hint_albedo;
+uniform int index;
+
+void fragment() {
+ALBEDO = texture(tex, vec3(UV.x, UV.y, float(index)));
+}
+
+```
+
+Note: `godot.TextureArray`s can only be sampled in shaders in the GLES3 backend. In GLES2, their data can be accessed via scripting, but there is no way to render them in a hardware-accelerated manner.
 **/
 @:libType
 @:csNative

--- a/godot/TileMap.hx
+++ b/godot/TileMap.hx
@@ -16,8 +16,6 @@ When doing physics queries against the tilemap, the cell coordinates are encoded
 extern class TileMap extends godot.Node2D {
 	/**
 		`settings_changed` signal.
-		
-		Emitted when a tilemap setting has changed.
 	**/
 	public var onSettingsChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSettingsChanged():Signal<Void->Void> {
@@ -293,7 +291,7 @@ extern class TileMap extends godot.Node2D {
 
 	#if doc_gen
 	/**		
-		Sets the tile index for the cell given by a Vector2.
+		Sets the tile index for the given cell.
 		
 		An index of `-1` clears the cell.
 		
@@ -320,7 +318,7 @@ extern class TileMap extends godot.Node2D {
 	public function setCell(x:Int, y:Int, tile:Int, ?flipX:Bool, ?flipY:Bool, ?transpose:Bool, ?autotileCoord:Null<godot.Vector2>):Void;
 	#else
 	/**		
-		Sets the tile index for the cell given by a Vector2.
+		Sets the tile index for the given cell.
 		
 		An index of `-1` clears the cell.
 		
@@ -347,7 +345,7 @@ extern class TileMap extends godot.Node2D {
 	public overload function setCell(x:Int, y:Int, tile:Int):Void;
 
 	/**		
-		Sets the tile index for the cell given by a Vector2.
+		Sets the tile index for the given cell.
 		
 		An index of `-1` clears the cell.
 		
@@ -374,7 +372,7 @@ extern class TileMap extends godot.Node2D {
 	public overload function setCell(x:Int, y:Int, tile:Int, flipX:Bool):Void;
 
 	/**		
-		Sets the tile index for the cell given by a Vector2.
+		Sets the tile index for the given cell.
 		
 		An index of `-1` clears the cell.
 		
@@ -401,7 +399,7 @@ extern class TileMap extends godot.Node2D {
 	public overload function setCell(x:Int, y:Int, tile:Int, flipX:Bool, flipY:Bool):Void;
 
 	/**		
-		Sets the tile index for the cell given by a Vector2.
+		Sets the tile index for the given cell.
 		
 		An index of `-1` clears the cell.
 		
@@ -428,7 +426,7 @@ extern class TileMap extends godot.Node2D {
 	public overload function setCell(x:Int, y:Int, tile:Int, flipX:Bool, flipY:Bool, transpose:Bool):Void;
 
 	/**		
-		Sets the tile index for the cell given by a Vector2.
+		Sets the tile index for the given cell.
 		
 		An index of `-1` clears the cell.
 		
@@ -457,74 +455,100 @@ extern class TileMap extends godot.Node2D {
 
 	#if doc_gen
 	/**		
-		Sets the tile index for the given cell.
+		Sets the tile index for the cell given by a Vector2.
 		
 		An index of `-1` clears the cell.
 		
-		Optionally, the tile can also be flipped or transposed.
+		Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
 		
 		Note: Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
 		
 		If you need these to be immediately updated, you can call `godot.TileMap.updateDirtyQuadrants`.
+		
+		@param autotileCoord If the parameter is null, then the default value is new Vector2(0, 0)
 	**/
 	@:native("SetCellv")
-	public function setCellv(position:godot.Vector2, tile:Int, ?flipX:Bool, ?flipY:Bool, ?transpose:Bool):Void;
+	public function setCellv(position:godot.Vector2, tile:Int, ?flipX:Bool, ?flipY:Bool, ?transpose:Bool, ?autotileCoord:Null<godot.Vector2>):Void;
 	#else
 	/**		
-		Sets the tile index for the given cell.
+		Sets the tile index for the cell given by a Vector2.
 		
 		An index of `-1` clears the cell.
 		
-		Optionally, the tile can also be flipped or transposed.
+		Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
 		
 		Note: Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
 		
 		If you need these to be immediately updated, you can call `godot.TileMap.updateDirtyQuadrants`.
+		
+		@param autotileCoord If the parameter is null, then the default value is new Vector2(0, 0)
 	**/
 	@:native("SetCellv")
 	public overload function setCellv(position:godot.Vector2, tile:Int):Void;
 
 	/**		
-		Sets the tile index for the given cell.
+		Sets the tile index for the cell given by a Vector2.
 		
 		An index of `-1` clears the cell.
 		
-		Optionally, the tile can also be flipped or transposed.
+		Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
 		
 		Note: Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
 		
 		If you need these to be immediately updated, you can call `godot.TileMap.updateDirtyQuadrants`.
+		
+		@param autotileCoord If the parameter is null, then the default value is new Vector2(0, 0)
 	**/
 	@:native("SetCellv")
 	public overload function setCellv(position:godot.Vector2, tile:Int, flipX:Bool):Void;
 
 	/**		
-		Sets the tile index for the given cell.
+		Sets the tile index for the cell given by a Vector2.
 		
 		An index of `-1` clears the cell.
 		
-		Optionally, the tile can also be flipped or transposed.
+		Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
 		
 		Note: Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
 		
 		If you need these to be immediately updated, you can call `godot.TileMap.updateDirtyQuadrants`.
+		
+		@param autotileCoord If the parameter is null, then the default value is new Vector2(0, 0)
 	**/
 	@:native("SetCellv")
 	public overload function setCellv(position:godot.Vector2, tile:Int, flipX:Bool, flipY:Bool):Void;
 
 	/**		
-		Sets the tile index for the given cell.
+		Sets the tile index for the cell given by a Vector2.
 		
 		An index of `-1` clears the cell.
 		
-		Optionally, the tile can also be flipped or transposed.
+		Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
 		
 		Note: Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
 		
 		If you need these to be immediately updated, you can call `godot.TileMap.updateDirtyQuadrants`.
+		
+		@param autotileCoord If the parameter is null, then the default value is new Vector2(0, 0)
 	**/
 	@:native("SetCellv")
 	public overload function setCellv(position:godot.Vector2, tile:Int, flipX:Bool, flipY:Bool, transpose:Bool):Void;
+
+	/**		
+		Sets the tile index for the cell given by a Vector2.
+		
+		An index of `-1` clears the cell.
+		
+		Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
+		
+		Note: Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
+		
+		If you need these to be immediately updated, you can call `godot.TileMap.updateDirtyQuadrants`.
+		
+		@param autotileCoord If the parameter is null, then the default value is new Vector2(0, 0)
+	**/
+	@:native("SetCellv")
+	public overload function setCellv(position:godot.Vector2, tile:Int, flipX:Bool, flipY:Bool, transpose:Bool, autotileCoord:Nullable1<godot.Vector2>):Void;
 	#end
 
 	/**		

--- a/godot/TileSet.hx
+++ b/godot/TileSet.hx
@@ -215,6 +215,8 @@ extern class TileSet extends godot.Resource {
 
 	/**		
 		Sets the tile's modulation color.
+		
+		Note: Modulation is performed by setting the tile's vertex color. To access this in a shader, use `COLOR` rather than `MODULATE` (which instead accesses the `godot.TileMap`'s `godot.CanvasItem.modulate` property).
 	**/
 	@:native("TileSetModulate")
 	public function tileSetModulate(id:Int, color:godot.Color):Void;

--- a/godot/Timer.hx
+++ b/godot/Timer.hx
@@ -16,8 +16,6 @@ Note: To create a one-shot timer without instantiating a node, use `godot.SceneT
 extern class Timer extends godot.Node {
 	/**
 		`timeout` signal.
-		
-		Emitted when the timer reaches 0.
 	**/
 	public var onTimeout(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTimeout():Signal<Void->Void> {

--- a/godot/TouchScreenButton.hx
+++ b/godot/TouchScreenButton.hx
@@ -18,8 +18,6 @@ You can configure TouchScreenButton to be visible only on touch devices, helping
 extern class TouchScreenButton extends godot.Node2D {
 	/**
 		`pressed` signal.
-		
-		Emitted when the button is pressed (down).
 	**/
 	public var onPressed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onPressed():Signal<Void->Void> {
@@ -28,8 +26,6 @@ extern class TouchScreenButton extends godot.Node2D {
 
 	/**
 		`released` signal.
-		
-		Emitted when the button is released (up).
 	**/
 	public var onReleased(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onReleased():Signal<Void->Void> {

--- a/godot/Tree.hx
+++ b/godot/Tree.hx
@@ -31,8 +31,6 @@ To iterate over all the `godot.TreeItem` objects in a `godot.Tree` object, use `
 extern class Tree extends godot.Control {
 	/**
 		`button_pressed` signal.
-		
-		Emitted when a button on the tree was pressed (see `treeItem.addButton`).
 	**/
 	public var onButtonPressed(get, never):Signal<(item:TreeItem, column:Int, id:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onButtonPressed():Signal<(item:TreeItem, column:Int, id:Int)->Void> {
@@ -41,8 +39,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`cell_selected` signal.
-		
-		Emitted when a cell is selected.
 	**/
 	public var onCellSelected(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCellSelected():Signal<Void->Void> {
@@ -51,8 +47,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`column_title_pressed` signal.
-		
-		Emitted when a column's title is pressed.
 	**/
 	public var onColumnTitlePressed(get, never):Signal<(column:Int)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onColumnTitlePressed():Signal<(column:Int)->Void> {
@@ -61,8 +55,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`custom_popup_edited` signal.
-		
-		Emitted when a cell with the `CELL_MODE_CUSTOM` is clicked to be edited.
 	**/
 	public var onCustomPopupEdited(get, never):Signal<(arrowClicked:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCustomPopupEdited():Signal<(arrowClicked:Bool)->Void> {
@@ -71,8 +63,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`empty_rmb` signal.
-		
-		Emitted when the right mouse button is pressed in the empty space of the tree.
 	**/
 	public var onEmptyRmb(get, never):Signal<(position:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onEmptyRmb():Signal<(position:Vector2)->Void> {
@@ -81,8 +71,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`empty_tree_rmb_selected` signal.
-		
-		Emitted when the right mouse button is pressed if right mouse button selection is active and the tree is empty.
 	**/
 	public var onEmptyTreeRmbSelected(get, never):Signal<(position:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onEmptyTreeRmbSelected():Signal<(position:Vector2)->Void> {
@@ -91,8 +79,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`item_activated` signal.
-		
-		Emitted when an item's label is double-clicked.
 	**/
 	public var onItemActivated(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemActivated():Signal<Void->Void> {
@@ -101,8 +87,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`item_collapsed` signal.
-		
-		Emitted when an item is collapsed by a click on the folding arrow.
 	**/
 	public var onItemCollapsed(get, never):Signal<(item:TreeItem)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemCollapsed():Signal<(item:TreeItem)->Void> {
@@ -111,8 +95,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`item_custom_button_pressed` signal.
-		
-		Emitted when a custom button is pressed (i.e. in a `CELL_MODE_CUSTOM` mode cell).
 	**/
 	public var onItemCustomButtonPressed(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemCustomButtonPressed():Signal<Void->Void> {
@@ -121,8 +103,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`item_double_clicked` signal.
-		
-		Emitted when an item's icon is double-clicked.
 	**/
 	public var onItemDoubleClicked(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemDoubleClicked():Signal<Void->Void> {
@@ -131,8 +111,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`item_edited` signal.
-		
-		Emitted when an item is edited.
 	**/
 	public var onItemEdited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemEdited():Signal<Void->Void> {
@@ -141,8 +119,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`item_rmb_edited` signal.
-		
-		Emitted when an item is edited using the right mouse button.
 	**/
 	public var onItemRmbEdited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemRmbEdited():Signal<Void->Void> {
@@ -151,8 +127,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`item_rmb_selected` signal.
-		
-		Emitted when an item is selected with the right mouse button.
 	**/
 	public var onItemRmbSelected(get, never):Signal<(position:Vector2)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemRmbSelected():Signal<(position:Vector2)->Void> {
@@ -161,8 +135,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`item_selected` signal.
-		
-		Emitted when an item is selected.
 	**/
 	public var onItemSelected(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onItemSelected():Signal<Void->Void> {
@@ -171,8 +143,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`multi_selected` signal.
-		
-		Emitted instead of `item_selected` if `select_mode` is `SELECT_MULTI`.
 	**/
 	public var onMultiSelected(get, never):Signal<(item:TreeItem, column:Int, selected:Bool)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onMultiSelected():Signal<(item:TreeItem, column:Int, selected:Bool)->Void> {
@@ -181,8 +151,6 @@ extern class Tree extends godot.Control {
 
 	/**
 		`nothing_selected` signal.
-		
-		Emitted when a left mouse button click does not select any item.
 	**/
 	public var onNothingSelected(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onNothingSelected():Signal<Void->Void> {
@@ -244,7 +212,7 @@ extern class Tree extends godot.Control {
 
 	#if doc_gen
 	/**		
-		Creates an item in the tree and adds it as a child of `parent`.
+		Creates an item in the tree and adds it as a child of `parent`, which can be either a valid `godot.TreeItem` or `null`.
 		
 		If `parent` is `null`, the root item will be the parent, or the new item will be the root itself if the tree is empty.
 		
@@ -254,7 +222,7 @@ extern class Tree extends godot.Control {
 	public function createItem(?parent:godot.Object, ?idx:Int):godot.TreeItem;
 	#else
 	/**		
-		Creates an item in the tree and adds it as a child of `parent`.
+		Creates an item in the tree and adds it as a child of `parent`, which can be either a valid `godot.TreeItem` or `null`.
 		
 		If `parent` is `null`, the root item will be the parent, or the new item will be the root itself if the tree is empty.
 		
@@ -264,7 +232,7 @@ extern class Tree extends godot.Control {
 	public overload function createItem():godot.TreeItem;
 
 	/**		
-		Creates an item in the tree and adds it as a child of `parent`.
+		Creates an item in the tree and adds it as a child of `parent`, which can be either a valid `godot.TreeItem` or `null`.
 		
 		If `parent` is `null`, the root item will be the parent, or the new item will be the root itself if the tree is empty.
 		
@@ -274,7 +242,7 @@ extern class Tree extends godot.Control {
 	public overload function createItem(parent:godot.Object):godot.TreeItem;
 
 	/**		
-		Creates an item in the tree and adds it as a child of `parent`.
+		Creates an item in the tree and adds it as a child of `parent`, which can be either a valid `godot.TreeItem` or `null`.
 		
 		If `parent` is `null`, the root item will be the parent, or the new item will be the root itself if the tree is empty.
 		
@@ -315,7 +283,7 @@ extern class Tree extends godot.Control {
 	public function isRootHidden():Bool;
 
 	/**		
-		Returns the next selected item after the given one, or `null` if the end is reached.
+		Returns the next selected `godot.TreeItem` after the given one, or `null` if the end is reached.
 		
 		If `from` is `null`, this returns the first selected item.
 	**/
@@ -366,7 +334,7 @@ extern class Tree extends godot.Control {
 		```
 		
 		func _ready():
-		$Tree.item_edited.connect(on_Tree_item_edited)
+		$Tree.connect("item_edited", self, "on_Tree_item_edited")
 		
 		func on_Tree_item_edited():
 		print($Tree.get_edited()) # This item just got edited (e.g. checked).
@@ -396,19 +364,19 @@ extern class Tree extends godot.Control {
 
 	#if doc_gen
 	/**		
-		Returns the rectangle area for the specified item. If `column` is specified, only get the position and size of that column, otherwise get the rectangle containing all columns.
+		Returns the rectangle area for the specified `godot.TreeItem`. If `column` is specified, only get the position and size of that column, otherwise get the rectangle containing all columns.
 	**/
 	@:native("GetItemAreaRect")
 	public function getItemAreaRect(item:godot.Object, ?column:Int):godot.Rect2;
 	#else
 	/**		
-		Returns the rectangle area for the specified item. If `column` is specified, only get the position and size of that column, otherwise get the rectangle containing all columns.
+		Returns the rectangle area for the specified `godot.TreeItem`. If `column` is specified, only get the position and size of that column, otherwise get the rectangle containing all columns.
 	**/
 	@:native("GetItemAreaRect")
 	public overload function getItemAreaRect(item:godot.Object):godot.Rect2;
 
 	/**		
-		Returns the rectangle area for the specified item. If `column` is specified, only get the position and size of that column, otherwise get the rectangle containing all columns.
+		Returns the rectangle area for the specified `godot.TreeItem`. If `column` is specified, only get the position and size of that column, otherwise get the rectangle containing all columns.
 	**/
 	@:native("GetItemAreaRect")
 	public overload function getItemAreaRect(item:godot.Object, column:Int):godot.Rect2;
@@ -477,7 +445,7 @@ extern class Tree extends godot.Control {
 	public function getScroll():godot.Vector2;
 
 	/**		
-		Causes the `godot.Tree` to jump to the specified item.
+		Causes the `godot.Tree` to jump to the specified `godot.TreeItem`.
 	**/
 	@:native("ScrollToItem")
 	public function scrollToItem(item:godot.Object):Void;

--- a/godot/TreeItem.hx
+++ b/godot/TreeItem.hx
@@ -386,38 +386,38 @@ extern abstract class TreeItem extends godot.Object {
 
 	#if doc_gen
 	/**		
-		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` index is used to identify the button when calling other methods. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
+		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
 	**/
 	@:native("AddButton")
 	public function addButton(column:Int, button:godot.Texture, ?buttonIdx:Int, ?disabled:Bool, ?tooltip:std.String):Void;
 	#else
 	/**		
-		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` index is used to identify the button when calling other methods. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
+		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
 	**/
 	@:native("AddButton")
 	public overload function addButton(column:Int, button:godot.Texture):Void;
 
 	/**		
-		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` index is used to identify the button when calling other methods. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
+		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
 	**/
 	@:native("AddButton")
 	public overload function addButton(column:Int, button:godot.Texture, buttonIdx:Int):Void;
 
 	/**		
-		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` index is used to identify the button when calling other methods. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
+		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
 	**/
 	@:native("AddButton")
 	public overload function addButton(column:Int, button:godot.Texture, buttonIdx:Int, disabled:Bool):Void;
 
 	/**		
-		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` index is used to identify the button when calling other methods. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
+		Adds a button with `godot.Texture` `button` at column `column`. The `button_idx` is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling `godot.TreeItem.getButtonCount` immediately after this method. Optionally, the button can be `disabled` and have a `tooltip`.
 	**/
 	@:native("AddButton")
 	public overload function addButton(column:Int, button:godot.Texture, buttonIdx:Int, disabled:Bool, tooltip:std.String):Void;
 	#end
 
 	/**		
-		Returns the number of buttons in column `column`. May be used to get the most recently added button's index, if no index was specified.
+		Returns the number of buttons in column `column`.
 	**/
 	@:native("GetButtonCount")
 	public function getButtonCount(column:Int):Int;

--- a/godot/Tween.hx
+++ b/godot/Tween.hx
@@ -26,6 +26,8 @@ Many methods require a property name, such as `"position"` above. You can find t
 Many of the methods accept `trans_type` and `ease_type`. The first accepts an `godot.Tween_TransitionType` constant, and refers to the way the timing of the animation is handled (see [https://easings.net/](easings.net) for some examples). The second accepts an `godot.Tween_EaseType` constant, and controls where the `trans_type` is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different `godot.Tween_TransitionType` constants with `godot.Tween_EaseType.inOut`, and use the one that looks best.
 
 [https://raw.githubusercontent.com/godotengine/godot-docs/master/img/tween_cheatsheet.png](Tween easing and transition types cheatsheet)
+
+Note: Tween methods will return `false` if the requested operation cannot be completed.
 **/
 @:libType
 @:csNative
@@ -34,8 +36,6 @@ Many of the methods accept `trans_type` and `ease_type`. The first accepts an `g
 extern class Tween extends godot.Node {
 	/**
 		`tween_all_completed` signal.
-		
-		Emitted when all processes in a tween end.
 	**/
 	public var onTweenAllCompleted(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTweenAllCompleted():Signal<Void->Void> {
@@ -44,8 +44,6 @@ extern class Tween extends godot.Node {
 
 	/**
 		`tween_completed` signal.
-		
-		Emitted when a tween ends.
 	**/
 	public var onTweenCompleted(get, never):Signal<(object:godot.Object, key:NodePath)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTweenCompleted():Signal<(object:godot.Object, key:NodePath)->Void> {
@@ -54,8 +52,6 @@ extern class Tween extends godot.Node {
 
 	/**
 		`tween_started` signal.
-		
-		Emitted when a tween starts.
 	**/
 	public var onTweenStarted(get, never):Signal<(object:godot.Object, key:NodePath)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTweenStarted():Signal<(object:godot.Object, key:NodePath)->Void> {
@@ -64,8 +60,6 @@ extern class Tween extends godot.Node {
 
 	/**
 		`tween_step` signal.
-		
-		Emitted at each step of the animation.
 	**/
 	public var onTweenStep(get, never):Signal<(object:godot.Object, key:NodePath, elapsed:Float, value:godot.Object)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onTweenStep():Signal<(object:godot.Object, key:NodePath, elapsed:Float, value:godot.Object)->Void> {

--- a/godot/UndoRedo.hx
+++ b/godot/UndoRedo.hx
@@ -43,8 +43,6 @@ If you don't need to register a method, you can leave `godot.UndoRedo.addDoMetho
 extern class UndoRedo extends godot.Object {
 	/**
 		`version_changed` signal.
-		
-		Called when `undo` or `redo` was called.
 	**/
 	public var onVersionChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onVersionChanged():Signal<Void->Void> {

--- a/godot/VideoPlayer.hx
+++ b/godot/VideoPlayer.hx
@@ -20,8 +20,6 @@ Warning: On HTML5, video playback will perform poorly due to missing architectur
 extern class VideoPlayer extends godot.Control {
 	/**
 		`finished` signal.
-		
-		Emitted when playback is finished.
 	**/
 	public var onFinished(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onFinished():Signal<Void->Void> {

--- a/godot/Viewport.hx
+++ b/godot/Viewport.hx
@@ -16,6 +16,8 @@ Viewports can also choose to be audio listeners, so they generate positional aud
 Also, viewports can be assigned to different screens in case the devices have multiple screens.
 
 Finally, viewports can also behave as render targets, in which case they will not be visible unless the associated texture is used to draw.
+
+Note: By default, a newly created Viewport in Godot 3.x will appear to be upside down. Enabling `godot.Viewport.renderTargetVFlip` will display the Viewport with the correct orientation.
 **/
 @:libType
 @:csNative
@@ -24,8 +26,6 @@ Finally, viewports can also behave as render targets, in which case they will no
 extern class Viewport extends godot.Node {
 	/**
 		`gui_focus_changed` signal.
-		
-		Emitted when a Control node grabs keyboard focus.
 	**/
 	public var onGuiFocusChanged(get, never):Signal<(node:Control)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onGuiFocusChanged():Signal<(node:Control)->Void> {
@@ -34,8 +34,6 @@ extern class Viewport extends godot.Node {
 
 	/**
 		`size_changed` signal.
-		
-		Emitted when the size of the viewport is changed, whether by `setSizeOverride`, resize of window, or some other means.
 	**/
 	public var onSizeChanged(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onSizeChanged():Signal<Void->Void> {
@@ -131,7 +129,7 @@ extern class Viewport extends godot.Node {
 	public var renderTargetClearMode:godot.Viewport_ClearMode;
 
 	/**		
-		If `true`, the result of rendering will be flipped vertically.
+		If `true`, the result of rendering will be flipped vertically. Since Viewports in Godot 3.x render upside-down, it's recommended to set this to `true` in most situations.
 	**/
 	@:native("RenderTargetVFlip")
 	public var renderTargetVFlip:Bool;
@@ -267,7 +265,7 @@ extern class Viewport extends godot.Node {
 	public function getWorld2d():godot.World2D;
 
 	/**		
-		Returns the 2D world of the viewport.
+		Returns the first valid `godot.World2D` for this viewport, searching the `godot.Viewport.world2d` property of itself and any Viewport ancestor.
 	**/
 	@:native("FindWorld2d")
 	public function findWorld2d():godot.World2D;
@@ -279,7 +277,7 @@ extern class Viewport extends godot.Node {
 	public function getWorld():godot.World;
 
 	/**		
-		Returns the 3D world of the viewport, or if none the world of the parent viewport.
+		Returns the first valid `godot.World` for this viewport, searching the `godot.Viewport.world` property of itself and any Viewport ancestor.
 	**/
 	@:native("FindWorld")
 	public function findWorld():godot.World;

--- a/godot/VisibilityEnabler.hx
+++ b/godot/VisibilityEnabler.hx
@@ -9,7 +9,7 @@ The VisibilityEnabler will disable `godot.RigidBody` and `godot.AnimationPlayer`
 
 If you just want to receive notifications, use `godot.VisibilityNotifier` instead.
 
-Note: VisibilityEnabler uses an approximate heuristic for performance reasons. It doesn't take walls and other occlusion into account. The heuristic is an implementation detail and may change in future versions. If you need precise visibility checking, use another method such as adding an `godot.Area` node as a child of a `godot.Camera` node and/or `Vector3.dot`.
+Note: VisibilityEnabler uses an approximate heuristic for performance reasons. It doesn't take walls and other occlusion into account (unless you are using `godot.Portal`s). The heuristic is an implementation detail and may change in future versions. If you need precise visibility checking, use another method such as adding an `godot.Area` node as a child of a `godot.Camera` node and/or `Vector3.dot`.
 
 Note: VisibilityEnabler will not affect nodes added after scene initialization.
 **/

--- a/godot/VisibilityNotifier.hx
+++ b/godot/VisibilityNotifier.hx
@@ -9,7 +9,7 @@ The VisibilityNotifier detects when it is visible on the screen. It also notifie
 
 If you want nodes to be disabled automatically when they exit the screen, use `godot.VisibilityEnabler` instead.
 
-Note: VisibilityNotifier uses an approximate heuristic for performance reasons. It doesn't take walls and other occlusion into account. The heuristic is an implementation detail and may change in future versions. If you need precise visibility checking, use another method such as adding an `godot.Area` node as a child of a `godot.Camera` node and/or `Vector3.dot`.
+Note: VisibilityNotifier uses an approximate heuristic for performance reasons. It doesn't take walls and other occlusion into account (unless you are using `godot.Portal`s). The heuristic is an implementation detail and may change in future versions. If you need precise visibility checking, use another method such as adding an `godot.Area` node as a child of a `godot.Camera` node and/or `Vector3.dot`.
 **/
 @:libType
 @:csNative
@@ -18,8 +18,6 @@ Note: VisibilityNotifier uses an approximate heuristic for performance reasons. 
 extern class VisibilityNotifier extends godot.CullInstance {
 	/**
 		`camera_entered` signal.
-		
-		Emitted when the VisibilityNotifier enters a `Camera`'s view.
 	**/
 	public var onCameraEntered(get, never):Signal<(camera:Camera)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCameraEntered():Signal<(camera:Camera)->Void> {
@@ -28,8 +26,6 @@ extern class VisibilityNotifier extends godot.CullInstance {
 
 	/**
 		`camera_exited` signal.
-		
-		Emitted when the VisibilityNotifier exits a `Camera`'s view.
 	**/
 	public var onCameraExited(get, never):Signal<(camera:Camera)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onCameraExited():Signal<(camera:Camera)->Void> {
@@ -38,8 +34,6 @@ extern class VisibilityNotifier extends godot.CullInstance {
 
 	/**
 		`screen_entered` signal.
-		
-		Emitted when the VisibilityNotifier enters the screen.
 	**/
 	public var onScreenEntered(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScreenEntered():Signal<Void->Void> {
@@ -48,8 +42,6 @@ extern class VisibilityNotifier extends godot.CullInstance {
 
 	/**
 		`screen_exited` signal.
-		
-		Emitted when the VisibilityNotifier exits the screen.
 	**/
 	public var onScreenExited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScreenExited():Signal<Void->Void> {

--- a/godot/VisibilityNotifier2D.hx
+++ b/godot/VisibilityNotifier2D.hx
@@ -18,8 +18,6 @@ Note: For performance reasons, VisibilityNotifier2D uses an approximate heuristi
 extern class VisibilityNotifier2D extends godot.Node2D {
 	/**
 		`screen_entered` signal.
-		
-		Emitted when the VisibilityNotifier2D enters the screen.
 	**/
 	public var onScreenEntered(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScreenEntered():Signal<Void->Void> {
@@ -28,8 +26,6 @@ extern class VisibilityNotifier2D extends godot.Node2D {
 
 	/**
 		`screen_exited` signal.
-		
-		Emitted when the VisibilityNotifier2D exits the screen.
 	**/
 	public var onScreenExited(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onScreenExited():Signal<Void->Void> {
@@ -38,8 +34,6 @@ extern class VisibilityNotifier2D extends godot.Node2D {
 
 	/**
 		`viewport_entered` signal.
-		
-		Emitted when the VisibilityNotifier2D enters a `Viewport`'s view.
 	**/
 	public var onViewportEntered(get, never):Signal<(viewport:Viewport)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onViewportEntered():Signal<(viewport:Viewport)->Void> {
@@ -48,8 +42,6 @@ extern class VisibilityNotifier2D extends godot.Node2D {
 
 	/**
 		`viewport_exited` signal.
-		
-		Emitted when the VisibilityNotifier2D exits a `Viewport`'s view.
 	**/
 	public var onViewportExited(get, never):Signal<(viewport:Viewport)->Void>;
 	@:dox(hide) @:noCompletion inline function get_onViewportExited():Signal<(viewport:Viewport)->Void> {

--- a/godot/VisualServer.hx
+++ b/godot/VisualServer.hx
@@ -30,8 +30,6 @@ In 2D, all visible objects are some form of canvas item. In order to be visible,
 extern class VisualServer {
 	/**
 		`frame_post_draw` signal.
-		
-		Emitted at the end of the frame, after the VisualServer has finished updating all the Viewports.
 	**/
 	public static var onFramePostDraw(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onFramePostDraw():Signal<Void->Void> {
@@ -40,8 +38,6 @@ extern class VisualServer {
 
 	/**
 		`frame_pre_draw` signal.
-		
-		Emitted at the beginning of the frame, before the VisualServer updates all the Viewports.
 	**/
 	public static var onFramePreDraw(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline static function get_onFramePreDraw():Signal<Void->Void> {
@@ -452,7 +448,7 @@ extern class VisualServer {
 	public static function materialGetParam(material:godot.RID, parameter:std.String):Dynamic;
 
 	/**		
-		Returns the default value for the param if available. Otherwise returns an empty `Variant`.
+		Returns the default value for the param if available. Returns `null` otherwise.
 	**/
 	@:native("MaterialGetParamDefault")
 	public static function materialGetParamDefault(material:godot.RID, parameter:std.String):Dynamic;

--- a/godot/VisualServer_EnvironmentToneMapper.hx
+++ b/godot/VisualServer_EnvironmentToneMapper.hx
@@ -6,27 +6,29 @@ package godot;
 @:csNative
 extern enum VisualServer_EnvironmentToneMapper {
 	/**		
-		Output color as they came in.
+		Output color as they came in. This can cause bright lighting to look blown out, with noticeable clipping in the output colors.
 	**/
 	Linear;
 
 	/**		
-		Use the Reinhard tonemapper.
+		Use the Reinhard tonemapper. Performs a variation on rendered pixels' colors by this formula: `color = color / (1 + color)`. This avoids clipping bright highlights, but the resulting image can look a bit dull.
 	**/
 	Reinhard;
 
 	/**		
-		Use the filmic tonemapper.
+		Use the filmic tonemapper. This avoids clipping bright highlights, with a resulting image that usually looks more vivid than `godot.VisualServer_EnvironmentToneMapper.reinhard`.
 	**/
 	Filmic;
 
 	/**		
-		Use the ACES tonemapper.
+		Use the legacy Godot version of the Academy Color Encoding System tonemapper. Unlike `godot.VisualServer_EnvironmentToneMapper.acesFitted`, this version of ACES does not handle bright lighting in a physically accurate way. ACES typically has a more contrasted output compared to `godot.VisualServer_EnvironmentToneMapper.reinhard` and `godot.VisualServer_EnvironmentToneMapper.filmic`.
+		
+		Note: This tonemapping operator will be removed in Godot 4.0 in favor of the more accurate `godot.VisualServer_EnvironmentToneMapper.acesFitted`.
 	**/
 	Aces;
 
 	/**		
-		Use the ACES Fitted tonemapper.
+		Use the Academy Color Encoding System tonemapper. ACES is slightly more expensive than other options, but it handles bright lighting in a more realistic fashion by desaturating it as it becomes brighter. ACES typically has a more contrasted output compared to `godot.VisualServer_EnvironmentToneMapper.reinhard` and `godot.VisualServer_EnvironmentToneMapper.filmic`.
 	**/
 	AcesFitted;
 }

--- a/godot/VisualShaderNode.hx
+++ b/godot/VisualShaderNode.hx
@@ -14,8 +14,6 @@ Visual shader graphs consist of various nodes. Each node in the graph is a separ
 extern abstract class VisualShaderNode extends godot.Resource {
 	/**
 		`editor_refresh_request` signal.
-		
-		Emitted when the node requests an editor refresh. Currently called only in setter of `visualShaderNodeTexture.source`, `VisualShaderNodeTexture`, and `VisualShaderNodeCubeMap` (and their derivatives).
 	**/
 	public var onEditorRefreshRequest(get, never):Signal<Void->Void>;
 	@:dox(hide) @:noCompletion inline function get_onEditorRefreshRequest():Signal<Void->Void> {


### PR DESCRIPTION
I regenerated the externs for Godot 3.4.5 after applying my update to the generator: https://github.com/HaxeGodot/extern-generator/pull/2/commits/457482a66024a3b4947c1e9281bb50db4c13dae7. It looks like mostly documentation changed, other than AnimationNodeOneShot_MixMode being renamed to AnimationNodeOneShot_MixModeEnum.